### PR TITLE
Output dtype now float32 for recon(),project()

### DIFF
--- a/svmbir/_utils.py
+++ b/svmbir/_utils.py
@@ -102,7 +102,7 @@ def read_sino_openmbir(rootPath, suffix, N_theta, N_z, N_y):
     fname_list = generateFileList(N_z, rootPath, suffix, numdigit=4)
 
     sizesArray = (N_z, N_theta, N_y)
-    x = np.zeros(sizesArray) 
+    x = np.zeros(sizesArray,dtype=np.float32)
 
     for i, fname in enumerate(fname_list):
 
@@ -137,7 +137,7 @@ def read_recon_openmbir(rootPath, suffix, N_x, N_y, N_z):
     fname_list = generateFileList(N_z, rootPath, suffix, numdigit=4)
 
     sizesArray = (N_z, N_y, N_x)
-    x = np.zeros(sizesArray)
+    x = np.zeros(sizesArray,dtype=np.float32)
 
     for i, fname in enumerate(fname_list):
 

--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -442,6 +442,7 @@ def recon(sino, angles,
 
     write_sino_openmbir(sino, paths['sino_name']+'_slice', '.2Dsinodata')
     write_sino_openmbir(weights, paths['wght_name']+'_slice', '.2Dweightdata')
+    del weights
 
     _cmd_exec(**cmd_args)
 
@@ -514,7 +515,7 @@ def project(angles, image, num_channels,
         ndarray: 3D numpy array containing sinogram with shape (num_views, num_slices, num_channels).
     """
     if num_threads is None:
-        num_threads=cpu_count(logical=False)
+        num_threads = cpu_count(logical=False)
 
     os.environ['OMP_NUM_THREADS'] = str(num_threads)
     os.environ['OMP_DYNAMIC'] = 'true'


### PR DESCRIPTION
I changed the dtype of the output array for recon() and project() to float32 to match the precision of the c-code. Mainly to avoid excessive memory usage for large images.

Also free up the "weights" array in recon() (if computed internally) before calling the execuable.