### PR TITLE
Raise value error when input for p is negative in recon().

### DIFF
--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -425,6 +425,9 @@ def recon(sino, angles,
     else:
         init_image_value = 0
 
+    if p < 0:
+        raise ValueError('recon() expects non-negative float for p.')
+
     reconparams = dict()
     reconparams['prior_model'] = 'QGGMRF'
     reconparams['init_image_value'] = init_image_value


### PR DESCRIPTION
I just use raise to raise value error when p is negative in recon().

I set p=-1.1 to test and returned below result in the terminal.

`Traceback (most recent call last):
  File "demo_3D_shepp_logan.py", line 43, in <module>
    recon = svmbir.recon(sino, angles, T=T, p=p, sharpness=sharpness, snr_db=snr_db)
  File "/anaconda2/envs/ipykernel_py3/lib/python3.7/site-packages/svmbir/svmbir.py", line 429, in recon
    raise ValueError('recon() expects non-negative float for p.')
ValueError: recon() expects non-negative float for p.
`