### PR TITLE
Update submodule commit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
      author_email='smajee@purdue.edu',
      packages=['svmbir'], 
      python_requires='>=3.6',
-     install_requires=['numpy', 'ruamel.yaml', 'matplotlib', 'psutil'], #external packages as dependencies
+     #external packages as dependencies
+     install_requires=['numpy','ruamel.yaml','matplotlib','psutil','pytest','scikit-image'], 
      package_data={'svmbir': [exec_file]}
      # package_data={'svmbir': ['sv-mbirct/bin/mbir_ct']}
      # ext_modules=[mbir_ct]


### PR DESCRIPTION
The sv-mbirct submodule got reverted to an old commit.

Developers should run 
```
git submodule sync
git submodule update
```
on your local repository especially if you're seeing conflicts with the submodule.  It was changed a couple weeks ago to point to a different fork, so you may see strange effects unless you run the above commands, or re-clone.
