### PR TITLE
Fix broken environment.yml for linux

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,7 @@
 name: svmbir
 dependencies:
   - python>=3.6
-  - numpy
-  - matplotlib
-  - ruamel.yaml
-  - pytest
   - scikit-image
-  - Cython
   - pip
   - pip:
-    - psutil
-#    - -r file:requirements.txt
+    - -r file:requirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,13 @@
 name: svmbir
 dependencies:
   - python>=3.6
+  - numpy
+  - matplotlib
+  - ruamel.yaml
+  - pytest
+  - scikit-image
+  - Cython
   - pip
   - pip:
-    - -r file:requirements.txt
+    - psutil
+#    - -r file:requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ numpy
 matplotlib
 ruamel.yaml
 pytest
-scikit-image
 Cython
 psutil


### PR DESCRIPTION
The conda environment created by the recent update of environment.yml (that moves everything to pip requirements) breaks the cython interface in linux.  The cython interface seems to install OK, but at runtime I get "undefined symbols" errors in the .so file.  This happens both when I build with CC=gcc and CC=icc.  It only happens for me in linux--mac/clang and mac/icc don't give me a problem.

When I create an environment with the older environment.yml the problem goes away.  The package list created in the older environment is quite a bit longer and it's not obvious to me which is the critical piece that's missing (or the wrong version). 

Until this is tracked down, this branch fixes the issue.
