### PR TITLE
Changed project() argument order to (image,angles,...)

### DIFF
--- a/demo/demo_2D_microscopy.py
+++ b/demo/demo_2D_microscopy.py
@@ -36,7 +36,7 @@ phantom = np.expand_dims(phantom, axis=0)
 angles = np.linspace(-tilt_angle, tilt_angle, num_views)
 
 # Generate sinogram by projecting phantom
-sino = svmbir.project(angles, phantom, max(num_rows, num_cols))
+sino = svmbir.project(phantom, angles, max(num_rows, num_cols))
 
 # Determine resulting number of views, slices, and channels
 (num_views, num_slices, num_channels) = sino.shape

--- a/demo/demo_2D_shepp_logan.py
+++ b/demo/demo_2D_shepp_logan.py
@@ -33,7 +33,7 @@ phantom = np.expand_dims(phantom, axis=0)
 angles = np.linspace(-tilt_angle, tilt_angle, num_views, endpoint=False)
 
 # Generate sinogram by projecting phantom
-sino = svmbir.project(angles, phantom, num_rows_cols )
+sino = svmbir.project(phantom, angles, num_rows_cols )
 
 # Determine resulting number of views, slices, and channels
 (num_views, num_slices, num_channels) = sino.shape

--- a/demo/demo_3D_microscopy.py
+++ b/demo/demo_3D_microscopy.py
@@ -38,7 +38,7 @@ phantom = svmbir.phantom.gen_microscopy_sample_3d(num_rows,num_cols,num_slices)
 angles = np.linspace(-tilt_angle, tilt_angle, num_views)
 
 # Generate sinogram by projecting phantom
-sino = svmbir.project(angles, phantom, max(num_rows, num_cols))
+sino = svmbir.project(phantom, angles, max(num_rows, num_cols))
 
 # Determine resulting number of views, slices, and channels
 (num_views, num_slices, num_channels) = sino.shape

--- a/demo/demo_3D_shepp_logan.py
+++ b/demo/demo_3D_shepp_logan.py
@@ -34,7 +34,7 @@ phantom = svmbir.phantom.gen_shepp_logan_3d(num_rows_cols,num_rows_cols,num_slic
 angles = np.linspace(-tilt_angle, tilt_angle, num_views, endpoint=False)
 
 # Generate sinogram by projecting phantom
-sino = svmbir.project(angles, phantom, num_rows_cols )
+sino = svmbir.project(phantom, angles, num_rows_cols )
 
 # Determine resulting number of views, slices, and channels
 (num_views, num_slices, num_channels) = sino.shape

--- a/demo/demo_multires_comparison.py
+++ b/demo/demo_multires_comparison.py
@@ -38,7 +38,7 @@ phantom = svmbir.phantom.gen_microscopy_sample_3d(num_rows,num_cols,num_slices)
 angles = np.linspace(-tilt_angle, tilt_angle, num_views)
 
 # Generate sinogram by projecting phantom
-sino = svmbir.project(angles, phantom, max(num_rows, num_cols))
+sino = svmbir.project(phantom, angles, max(num_rows, num_cols))
 
 # Determine resulting number of views, slices, and channels
 (num_views, num_slices, num_channels) = sino.shape

--- a/demo/demo_prox.py
+++ b/demo/demo_prox.py
@@ -36,7 +36,7 @@ phantom = svmbir.phantom.gen_shepp_logan_3d(num_rows_cols,num_rows_cols,num_slic
 angles = np.linspace(-tilt_angle, tilt_angle, num_views, endpoint=False)
 
 # Generate sinogram by projecting phantom
-sino = svmbir.project(angles, phantom, num_rows_cols )
+sino = svmbir.project(phantom, angles, num_rows_cols )
 
 # Determine resulting number of views, slices, and channels
 (num_views, num_slices, num_channels) = sino.shape

--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -306,22 +306,22 @@ def recon(sino, angles,
 
 
 
-def project(angles, image, num_channels,
+def project(image, angles, num_channels,
             delta_channel = 1.0, delta_pixel = 1.0, center_offset = 0.0, roi_radius = None,
             num_threads = None, svmbir_lib_path = __svmbir_lib_path, delete_temps = True, 
             object_name = 'object', verbose = 1):
-    """project(angles, image, num_channels, delta_channel = 1.0, delta_pixel = 1.0, center_offset = 0.0, roi_radius = None, num_threads = None, svmbir_lib_path = '~/.cache/svmbir', delete_temps = True, object_name = 'object', verbose = 1)
+    """project(image, angles, num_channels, delta_channel = 1.0, delta_pixel = 1.0, center_offset = 0.0, roi_radius = None, num_threads = None, svmbir_lib_path = '~/.cache/svmbir', delete_temps = True, object_name = 'object', verbose = 1)
 
     Computes 3D parallel beam forward-projection.
 
     Args:
-        angles (ndarray):
-            1D numpy array of view angles in radians.
-            'angles[k]' is the angle in radians for view :math:`k`.
         image (ndarray):
             3D numpy array of image being projected.
             The image shape is (num_slices,num_rows,num_cols). The output will contain 'num_slices' projections.
             Note the image is considered 0 outside the 'roi_radius' (disregarded pixels).
+        angles (ndarray):
+            1D numpy array of view angles in radians.
+            'angles[k]' is the angle in radians for view :math:`k`.
         num_channels (int):
             Number of sinogram channels.
         delta_channel (float, optional):
@@ -346,6 +346,15 @@ def project(angles, image, num_channels,
     Returns:
         ndarray: 3D numpy array containing projection with shape (num_views, num_slices, num_channels).
     """
+
+    # Check for order of first 2 arguments. From v0.2.4, order is project(image,angles,...)
+    if len(image.shape) < len(angles.shape):
+        print("WARNING: Check the argument order svmbir.project(image,angles,...)")
+        print("**This is the correct order as of svmbir v0.2.4")
+        print("**Swapping and proceeding...")
+        temp_id = image
+        image = angles
+        angles = temp_id
 
     if num_threads is None :
         num_threads = cpu_count(logical=False)


### PR DESCRIPTION
Argument order of `svmbir.project()` is changed from
`svmbir.project(angles,image,...)` to
`svmbir.project(image,angles,...)`.

This makes the function more consistent with the `recon` and new `backproject` functions.

A check is also added for the `project()` input arguments' shape so that if the original order is used, a warning is printed, the array id's are swapped, and the function proceeds. So any existing user code that uses the `project()` function won't break.

All the demos that use the function are also changed accordingly.