### PR TITLE
Added optional param sigma_p to control proxial map term regularizati…

### DIFF
--- a/demo/demo_prox.py
+++ b/demo/demo_prox.py
@@ -19,15 +19,15 @@ num_views = 144
 tilt_angle = np.pi/2 # Tilt range of +-90deg
 
 # Reconstruction parameters
-sigma_x = 0.2
+sigma_p = 0.2
 snr_db = 40.0
 
 # Multi-resolution works much better for limited and sparse view reconstruction
 max_resolutions=1 # Use 2 additional resolutions to do reconstruction
 
 # Display parameters
-vmin = None
-vmax = None
+vmin = 1.0
+vmax = 1.2
 
 # Generate phantom with a single slice
 phantom = svmbir.phantom.gen_shepp_logan_3d(num_rows_cols,num_rows_cols,num_slices)
@@ -45,7 +45,7 @@ sino = svmbir.project(phantom, angles, num_rows_cols )
 phantom_rot = np.swapaxes(phantom, 1, 2)
 
 # Perform fixed resolution MBIR reconstruction using proximal map input
-recon = svmbir.recon(sino, angles, max_resolutions=max_resolutions, init_image=phantom_rot, prox_image=phantom_rot, positivity=False, sigma_x=sigma_x, snr_db=snr_db)
+recon = svmbir.recon(sino, angles, max_resolutions=max_resolutions, init_image=phantom_rot, prox_image=phantom_rot, positivity=False, sigma_p=sigma_p, snr_db=snr_db)
 
 # create output folder
 os.makedirs('output', exist_ok=True)

--- a/docs/source/svmbir.rst
+++ b/docs/source/svmbir.rst
@@ -9,6 +9,7 @@ svmbir
 
    .. autosummary::
 
+      auto_sigma_p
       auto_sigma_x
       auto_sigma_y
       backproject

--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -80,10 +80,10 @@ In this case, the reconstruction solves the optimization problem:
 
 .. math::
 
-    {\hat x} = \arg \min_x \left\{ f(x) + \frac{1}{2\sigma_x^2} \Vert x -v \Vert^2 \right\}
+    {\hat x} = \arg \min_x \left\{ f(x) + \frac{1}{2\sigma_p^2} \Vert x -v \Vert^2 \right\}
 
 where the quantities correspond to the following python variables:
 
 * :math:`v` corresponds to ``prox_image``
-* :math:`\sigma_x` corresponds to ``sigma_x``
+* :math:`\sigma_p` corresponds to ``sigma_p``
 

--- a/svmbir/__init__.py
+++ b/svmbir/__init__.py
@@ -1,3 +1,3 @@
 from .svmbir import *
 from .phantom import *
-__all__ =['_svmbir_lib_path','_clear_cache','auto_sigma_x','auto_sigma_y', 'calc_weights','project','backproject','recon']
+__all__ =['_svmbir_lib_path','_clear_cache','auto_sigma_x','auto_sigma_p','auto_sigma_y', 'calc_weights','project','backproject','recon']

--- a/svmbir/_utils.py
+++ b/svmbir/_utils.py
@@ -100,7 +100,7 @@ def test_params_line3(sigma_y, snr_db, weights, weight_type):
     return sigma_y, snr_db, weights, weight_type
 
 
-def test_params_line4(sharpness, positivity, sigma_x):
+def test_params_line4(sharpness, positivity, sigma_x, sigma_p):
 
     # Convert parameter ints to floats
     if isinstance(sharpness,int):
@@ -119,8 +119,12 @@ def test_params_line4(sharpness, positivity, sigma_x):
     if not ((sigma_x is None) or (isinstance(sigma_x, float) and (sigma_x > 0))):
         warnings.warn("Parameter sigma_x is not valid float; Setting sigma_x = None.")
         sigma_x = None
+    
+    if not ((sigma_p is None) or (isinstance(sigma_p, float) and (sigma_p > 0))):
+        warnings.warn("Parameter sigma_p is not valid float; Setting sigma_p = None.")
+        sigma_p = None
 
-    return sharpness, positivity, sigma_x
+    return sharpness, positivity, sigma_x, sigma_p
 
 
 def test_pqtb_values(p, q, T, b_interslice):

--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -100,7 +100,6 @@ def auto_sigma_y(sino, weights, snr_db = 30.0, delta_pixel = 1.0, delta_channel 
 
     return sigma_y
 
-
 def auto_sigma_x(sino, delta_channel = 1.0, sharpness = 0.0 ):
     """Computes the automatic value of ``sigma_x`` for use in MBIR reconstruction.
 
@@ -116,21 +115,28 @@ def auto_sigma_x(sino, delta_channel = 1.0, sharpness = 0.0 ):
     Returns:
         float: Automatic value of regularization parameter.
     """
-    (num_views, num_slices, num_channels) = sino.shape
+    return 0.2 * auto_sigma_prior(sino, delta_channel, sharpness)
 
-    # Compute indicator function for sinogram support
-    sino_indicator = _sino_indicator(sino)
-
-    # Compute a typical image value by dividing average sinogram value by a typical projection path length
-    typical_img_value = np.average(sino, weights=sino_indicator) / (num_channels * delta_channel)
-
-    # Compute sigma_x as a fraction of the typical image value
-    sigma_x = 0.2 * (2 ** sharpness) * typical_img_value
-
-    return sigma_x
 
 def auto_sigma_p(sino, delta_channel = 1.0, sharpness = 0.0 ):
-    """Computes the automatic value of ``sigma_p`` for use in MBIR reconstruction.
+    """Computes the automatic value of ``sigma_p`` for use in proximal map estimation.
+
+    Args:
+        sino (ndarray):
+            3D numpy array of sinogram data with shape (num_views,num_slices,num_channels)
+        delta_channel (float, optional):
+            [Default=1.0] Scalar value of detector channel spacing in :math:`ALU`.
+        sharpness (float, optional):
+            [Default=0.0] Scalar value that controls level of sharpness.
+            ``sharpness=0.0`` is neutral; ``sharpness>0`` increases sharpness; ``sharpness<0`` reduces sharpness
+
+    Returns:
+        float: Automatic value of regularization parameter.
+    """
+    return 1.0 * auto_sigma_prior(sino, delta_channel, sharpness)
+
+def auto_sigma_prior(sino, delta_channel = 1.0, sharpness = 0.0 ):
+    """Computes the automatic value of prior model regularization term for use in MBIR reconstruction or proximal map estimation. This subroutine is called by ``auto_sigma_x`` in MBIR reconstruction, or ``auto_sigma_p`` in proximal map estimation.
 
     Args:
         sino (ndarray):
@@ -153,9 +159,9 @@ def auto_sigma_p(sino, delta_channel = 1.0, sharpness = 0.0 ):
     typical_img_value = np.average(sino, weights=sino_indicator) / (num_channels * delta_channel)
 
     # Compute sigma_p as the typical image value when sharpness==0
-    sigma_p = (2 ** sharpness) * typical_img_value
+    sigma_prior = (2 ** sharpness) * typical_img_value
 
-    return sigma_p
+    return sigma_prior
 
 
 def auto_num_rows(num_channels, delta_channel, delta_pixel):

--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -240,9 +240,9 @@ def recon(sino, angles,
             Ignored if prox_image is not None.
             If None and prox_image is also None, automatically set with auto_sigma_x. The parameter sigma_x can be used to directly control regularization, but this is only recommended for expert users.
         
-        sigma_p (float, optional): [Default=None] Scalar value :math:`>0` that specifies the regularization level of proximal map prior term.
+        sigma_p (float, optional): [Default=None] Scalar value :math:`>0` that specifies the proximal map parameter.
             Ignored if prox_image is None.
-            If None and proximal image is not None, automatically set with auto_sigma_p. The parameter sigma_p can be used to directly control regularization for the prior term of proximal map, but this is only recommended for expert users.
+            If None and proximal image is not None, automatically set with auto_sigma_p. The parameter sigma_p can be used to directly control the proximal map parameter.
 
         p (float, optional): [Default=1.2] Scalar value in range :math:`[1,2]` that specifies the qGGMRF shape parameter.
 

--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -238,11 +238,11 @@ def recon(sino, angles,
 
         sigma_x (float, optional): [Default=None] Scalar value :math:`>0` that specifies the qGGMRF scale parameter.
             Ignored if prox_image is not None.
-            If None and prox_image is also None, automatically set with auto_sigma_x. The parameter sigma_x can be used to directly control regularization, but this is only recommended for expert users.
+            If None and prox_image is also None, automatically set with auto_sigma_x. Regularization should be controled with the ``sharpness`` parameter, but ``sigma_x`` can be set directly by expert users.
         
         sigma_p (float, optional): [Default=None] Scalar value :math:`>0` that specifies the proximal map parameter.
             Ignored if prox_image is None.
-            If None and proximal image is not None, automatically set with auto_sigma_p. The parameter sigma_p can be used to directly control the proximal map parameter.
+            If None and proximal image is not None, automatically set with auto_sigma_p. Regularization should be controled with the ``sharpness`` parameter, but ``sigma_p`` can be set directly by expert users.
 
         p (float, optional): [Default=1.2] Scalar value in range :math:`[1,2]` that specifies the qGGMRF shape parameter.
 
@@ -257,7 +257,7 @@ def recon(sino, angles,
         sharpness (float, optional):
             [Default=0.0] Scalar value that controls level of sharpness.
             ``sharpness=0.0`` is neutral; ``sharpness>0`` increases sharpness; ``sharpness<0`` reduces sharpness.
-            Ignored if sigma_x is not None in qGGMRF mode, or if sigma_p is not None in proximal map mode.
+            Ignored if ``sigma_x`` is not None in qGGMRF mode, or if ``sigma_p`` is not None in proximal map mode.
 
         positivity (bool, optional): [Default=True] Boolean value that determines if positivity constraint is enforced. The positivity parameter defaults to True; however, it should be changed to False when used in applications that can generate negative image values.
 


### PR DESCRIPTION
See commit message for detailed changes.
Tested demo_2D_shepp_logan.py, and the recons are visually the same as before.
Tested demo_prox.py by changing sigma_x to sigma_p without changing the actual value. Recons are visually the same as before.