### PR TITLE
doc string formatting fix in sino_sort function

### DIFF
--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -38,9 +38,11 @@ def sino_sort(sino, angles, weights=None):
         sino (ndarray): 3D numpy array of unsorted sinogram data with shape (num_views, num_slices, num_channels)
         angles (ndarray): 1D unsorted array of view angles in radians.
         weights (ndarray, optional): [Default=None] 3D unsorted array of weights with same shape as sino. 
+    
     Returns:
-        A tuple (sino, angles) when weights=None
-        A tuple (sino, angles, weights) if weights is not None.
+        - A tuple (sino, angles) when weights=None
+        - A tuple (sino, angles, weights) if weights is not None.
+        
         The arrays are sorted along the view axis so that they have monotone increasing view angles in the interval :math:`[0,2\pi)`.
     """ 
 


### PR DESCRIPTION
Fixed doc string formatting of return value description. 
Before:
![Screen Shot 2021-10-13 at 10 10 39 AM](https://user-images.githubusercontent.com/7671736/137188219-357aad48-0c57-4eda-b983-43c28ac7570f.png)

After:
![Screen Shot 2021-10-13 at 2 00 36 PM](https://user-images.githubusercontent.com/7671736/137188255-55037cb1-df5d-4fe3-ab5e-88525821773d.png)

