### PR TITLE
Make fixes for issue #213: negative weights

### DIFF
--- a/svmbir/_utils.py
+++ b/svmbir/_utils.py
@@ -143,8 +143,12 @@ def test_args_inits(init_image, prox_image, init_proj, weights, weight_type):
         warnings.warn("Parameter init_proj is not a valid 3D ndarray; Setting init_proj = None.")
         init_proj = None
 
-    if not ((weights is None) or (isinstance(weights, np.ndarray) or (weights.ndim == 3))):
+    if not ((weights is None) or (isinstance(weights, np.ndarray) and (weights.ndim == 3))):
         warnings.warn("Parameter weights is not valid 3D np array; Setting weights = None.")
+        weights = None
+
+    if not ((weights is None) or (np.amin(weights) >= 0.0)):
+        warnings.warn("Parameter weights contains negative values; Setting weights = None.")
         weights = None
 
     list_of_weights = ['unweighted', 'transmission', 'transmission_root', 'emission']

--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -92,7 +92,7 @@ def calc_weights(sino, weight_type ):
     elif weight_type == 'transmission_root' :
         weights = np.exp(-sino / 2)
     elif weight_type == 'emission' :
-        weights = 1 / (sino + 0.1)
+        weights = 1 / (np.absolute(sino)  + 0.1)
     else :
         raise Exception("calc_weights: undefined weight_type {}".format(weight_type))
 


### PR DESCRIPTION
This is to check for negative weights and to fix a case when the automatic weights could be negative. 
In addition, I think I found a bug in a test where an ``or`` should have been an ``and``. 
See if you agree. 