### PR TITLE
Fix for numpy version mismatch

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include MANIFEST.in
 include pytest.ini
 include LICENSE
-include environment.yml
+# include environment.yml
 include requirements.txt
 include pyproject.toml
 

--- a/dev_scripts/build_dist.sh
+++ b/dev_scripts/build_dist.sh
@@ -9,12 +9,12 @@
 # IMPORTANT: If building macOS wheels, run script on macOS 10.14 so that binaries will be
 # compatibile with macOS>=10.14
 #
-# Wheels are delocated to fix a library incompatibility across macOS >= 10.14. 
+# Wheels are delocated to fix a library incompatibility across macOS >= 10.14.
 #
 
 # Set these accordingly:
 
-python_versions=("3.8" "3.9" "3.10")
+python_versions=("3.7" "3.8" "3.9" "3.10")
 CC=gcc
 
 # check for a valid compiler
@@ -33,20 +33,20 @@ echo "*************** sdist ******************"
 python setup.py sdist
 
 echo "*********************************************************"
-echo "**** Building wheels" 
+echo "**** Building wheels"
 echo "**** Python ${python_versions[@]}"
 echo "**** Compiler: ${CC}"
 echo "*********************************************************"
 
 for pyv in ${python_versions[@]}; do
-    echo "*********** Create environment ${pyv} *************" 
+    echo "*********** Create environment ${pyv} *************"
     conda create --name sv${pyv} python=$pyv --yes
     conda activate sv${pyv}
     pip install -r requirements.txt
     pip install setuptools delocate
 
     echo "****"
-    echo "**** Building wheel for python ${pyv}, CC=${CC} " 
+    echo "**** Building wheel for python ${pyv}, CC=${CC} "
     echo "****"
     CC=$CC python setup.py bdist_wheel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy~=1.22.1", "Cython"]
+requires = ["setuptools", "wheel", "numpy>=1.22", "Cython"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "Cython"]
+requires = ["setuptools", "wheel", "numpy~=1.22.1", "Cython"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.22", "Cython"]
+requires = ["setuptools", "wheel", "numpy==1.21.*", "Cython"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy~=1.22.1
-Pillow~=8.4.0
-Cython~=0.29.21
-ruamel.yaml~=0.16.12
-pytest~=6.2.2
-psutil~=5.8.0
+numpy>=1.22
+psutil>=5.8
+Pillow
+Cython
+ruamel.yaml
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.12
+numpy~=1.22.1
 Pillow~=8.4.0
 Cython~=0.29.21
 ruamel.yaml~=0.16.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.22
+numpy==1.21.*
 psutil>=5.8
 Pillow
 Cython

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ packages_dir = 'svmbir'
 packages = [packages_dir]
 src_dir = packages_dir + "/sv-mbirct/src/"
 
+# Dependencies for running svmbir. Dependencies for build/installation are in pyproject.toml
+install_requires=['numpy>=1.22','psutil>=5.8','Pillow']
+
 # Check for compiled executable
 if os.path.exists('svmbir/sv-mbirct/bin/mbir_ct'):
     exec_file = 'sv-mbirct/bin/mbir_ct'
@@ -33,12 +36,8 @@ elif os.path.exists('svmbir/sv-mbirct/bin/mbir_ct.exe'):
 else:
     exec_file = None
 
-
 # Set up install for Cython or Command line interface
 if os.environ.get('CLIB') != 'CMD_LINE':
-    # Cython interface install set up
-
-    install_requires=['numpy~=1.22.1','Cython','psutil','Pillow']  # external package dependencies
 
     # Check that compiler is set
     if os.environ.get('CC') not in ['gcc','icc','clang','msvc'] and re.findall('gcc',str(os.environ.get('CC')))==[]:
@@ -93,7 +92,7 @@ else:
     else:
         package_data={'svmbir': [exec_file]}
 
-    install_requires=['numpy','ruamel.yaml','psutil','Pillow']  # external package dependencies
+    install_requires.append('ruamel.yaml')
     cmdclass = {}
     ext_modules = None
 
@@ -112,5 +111,4 @@ setup(name=name,
       package_data=package_data,
       cmdclass=cmdclass,
       ext_modules=ext_modules)
-
 

--- a/setup.py
+++ b/setup.py
@@ -39,13 +39,8 @@ else:
 # Set up install for Cython or Command line interface
 if os.environ.get('CLIB') != 'CMD_LINE':
 
-    # Check that compiler is set
-    if os.environ.get('CC') not in ['gcc','icc','clang','msvc'] and re.findall('gcc',str(os.environ.get('CC')))==[]:
-        warnings.warn('CC environment variable not set to valid value. Using default CC=gcc.')
-        os.environ["CC"] = 'gcc'
-
-    # OpenMP gcc compile: tested for MacOS and Linux
-    if os.environ.get('CC') =='gcc' or re.findall('gcc',str(os.environ.get('CC')))!=[]:
+    # Check for compiler env variable. If not set, assume it's a gcc build (linux & macOS only).
+    if os.environ.get('CC') not in ['icc','clang','msvc']:
         extra_compile_args=["-std=c11","-O3","-fopenmp","-Wno-unknown-pragmas"]
         extra_link_args=["-lm","-fopenmp"]
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ packages = [packages_dir]
 src_dir = packages_dir + "/sv-mbirct/src/"
 
 # Dependencies for running svmbir. Dependencies for build/installation are in pyproject.toml
-install_requires=['numpy>=1.22','psutil>=5.8','Pillow']
+install_requires=['numpy==1.21.*','psutil>=5.8','Pillow']
 
 # Check for compiled executable
 if os.path.exists('svmbir/sv-mbirct/bin/mbir_ct'):

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,9 @@ else:
     cmdclass = {}
     ext_modules = None
 
+# set cython language level for all .pyx modules to Python 3
+for e in ext_modules:
+    e.cython_directives = {'language_level': "3"}
 
 setup(name=name,
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 if os.environ.get('CLIB') != 'CMD_LINE':
     # Cython interface install set up
 
-    install_requires=['numpy','Cython','psutil','Pillow']  # external package dependencies
+    install_requires=['numpy~=1.22.1','Cython','psutil','Pillow']  # external package dependencies
 
     # Check that compiler is set
     if os.environ.get('CC') not in ['gcc','icc','clang','msvc'] and re.findall('gcc',str(os.environ.get('CC')))==[]:


### PR DESCRIPTION
Updates to requirements. 
In particular `numpy>=1.22` was added to pyproject.toml, setup.py, and requirements.txt
in order to solve issue #224 error caused when there's a mismatch in numpy version between building and running the package.

Note this error could re-appear in future numpy versions.