### PR TITLE
Update default image dimensions for fan geometry

### DIFF
--- a/demo/demo_fanbeam.py
+++ b/demo/demo_fanbeam.py
@@ -9,10 +9,11 @@ Fan beam demo
 
 # Simulated sinogram parameters
 geometry = 'fan'
-dist_source_detector = 512.0
+dist_source_detector = 1000.0
+delta_channel = 1.0
 magnification = 2.0
 num_views = 512
-num_channels = 512
+num_channels = 256
 angles = np.linspace(-np.pi, np.pi, num_views, endpoint=False)
 
 # Reconstruction parameters
@@ -25,10 +26,10 @@ snr_db = 40.0
 # Generate phantom with a single slice
 phantom = svmbir.phantom.gen_shepp_logan(img_size,img_size)
 phantom = np.expand_dims(phantom, axis=0)
-sino = svmbir.project(phantom, angles, num_channels, geometry=geometry, dist_source_detector=dist_source_detector, magnification=magnification)
+sino = svmbir.project(phantom, angles, num_channels, geometry=geometry, dist_source_detector=dist_source_detector, magnification=magnification, delta_channel=delta_channel)
 
 # Perform MBIR reconstruction
-recon = svmbir.recon(sino, angles, num_rows=img_size, num_cols=img_size, T=T, p=p, sharpness=sharpness, snr_db=snr_db, geometry=geometry, dist_source_detector=dist_source_detector, magnification=magnification)
+recon = svmbir.recon(sino, angles, num_rows=img_size, num_cols=img_size, T=T, p=p, sharpness=sharpness, snr_db=snr_db, geometry=geometry, dist_source_detector=dist_source_detector, magnification=magnification, delta_channel=delta_channel)
 
 # Compute Normalized Root Mean Squared Error
 nrmse = svmbir.phantom.nrmse(recon[0], phantom[0])
@@ -39,7 +40,7 @@ vmax = 1.2
 plt.figure(); plt.imshow(phantom[0],vmin=vmin,vmax=vmax,cmap='gray'); plt.colorbar()
 plt.title('Shepp Logan Phantom')
 
-plt.figure(); plt.imshow(np.squeeze(sino),cmap='gray'); plt.colorbar()
+plt.figure(); plt.imshow(np.squeeze(sino).T,cmap='gray'); plt.colorbar()
 plt.title('Sinogram')
 
 plt.figure(); plt.imshow(recon[0],vmin=vmin,vmax=vmax,cmap='gray'); plt.colorbar()


### PR DESCRIPTION
- Changed the default image dimensions (delta_pixel, num_rows, num_cols) for fan geometry in the ``project``,``recon``, and ``backproject`` operators
- Updated docstrings accordingly
- Replaced the two identical functions ``auto_num_rows`` and ``auto_num_cols`` with a single function ``auto_img_size`` that returns both num_rows,num_cols.  Also added a ``geometry`` input argument.