### PR TITLE
Update demos to use consistent parameter settings

### DIFF
--- a/demo/demo_2D_microscopy.py
+++ b/demo/demo_2D_microscopy.py
@@ -18,11 +18,13 @@ num_views = 64
 tilt_angle = np.pi/3 # Tilt range of +-60deg
 
 # Reconstruction parameters
-T = 1.0
+snr_db = 40.0
+sharpness = 0.0
+T = 0.1
 p = 1.2
-sharpness = 1.0
-snr_db = 30.0
-max_resolutions=2
+
+# Multi-resolution works much better for limited and sparse view reconstruction
+max_resolutions=2 # Use 2 additional resolutions to do reconstruction
 
 # Display parameters
 vmin = 0.0

--- a/demo/demo_2D_shepp_logan.py
+++ b/demo/demo_2D_shepp_logan.py
@@ -16,10 +16,13 @@ num_views = 144
 tilt_angle = np.pi/2 # Tilt range of +-90deg
 
 # Reconstruction parameters
-T = 0.1
-p = 1.1
-sharpness = 1.0
 snr_db = 40.0
+sharpness = 0.0
+T = 0.1
+p = 1.2
+
+# Multi-resolution works much better for limited and sparse view reconstruction
+max_resolutions=2 # Use 2 additional resolutions to do reconstruction
 
 # Display parameters
 vmin = 1.0
@@ -39,7 +42,7 @@ sino = svmbir.project(phantom, angles, num_rows_cols )
 (num_views, num_slices, num_channels) = sino.shape
 
 # Perform MBIR reconstruction
-recon = svmbir.recon(sino, angles, T=T, p=p, sharpness=sharpness, snr_db=snr_db)
+recon = svmbir.recon(sino, angles, T=T, p=p, sharpness=sharpness, snr_db=snr_db, max_resolutions = max_resolutions)
 
 # Compute Normalized Root Mean Squared Error
 nrmse = svmbir.phantom.nrmse(recon[0], phantom[0])

--- a/demo/demo_3D_microscopy.py
+++ b/demo/demo_3D_microscopy.py
@@ -19,9 +19,9 @@ num_views = 64
 tilt_angle = np.pi/3 # Tilt range of +-60deg
 
 # Reconstruction parameters
-sharpness = 2.0
+snr_db = 40.0
+sharpness = 0.0
 T = 0.25
-snr_db = 30.0
 p = 1.2
 
 # Multi-resolution works much better for limited and sparse view reconstruction

--- a/demo/demo_3D_shepp_logan.py
+++ b/demo/demo_3D_shepp_logan.py
@@ -18,10 +18,13 @@ num_views = 144
 tilt_angle = np.pi/2 # Tilt range of +-90deg
 
 # Reconstruction parameters
-T = 0.1
-p = 1.1
-sharpness = 2.0
 snr_db = 40.0
+sharpness = 0.0
+T = 0.1
+p = 1.2
+
+# Multi-resolution works much better for limited and sparse view reconstruction
+max_resolutions=2 # Use 2 additional resolutions to do reconstruction
 
 # Display parameters
 vmin = 1.0
@@ -40,7 +43,7 @@ sino = svmbir.project(phantom, angles, num_rows_cols )
 (num_views, num_slices, num_channels) = sino.shape
 
 # Perform fixed resolution MBIR reconstruction
-recon = svmbir.recon(sino, angles, T=T, p=p, sharpness=sharpness, snr_db=snr_db)
+recon = svmbir.recon(sino, angles, T=T, p=p, sharpness=sharpness, snr_db=snr_db, max_resolutions = max_resolutions)
 
 # Compute Normalized Root Mean Squared Error
 nrmse = svmbir.phantom.nrmse(recon, phantom)

--- a/demo/demo_fanbeam.py
+++ b/demo/demo_fanbeam.py
@@ -18,10 +18,13 @@ angles = np.linspace(-np.pi, np.pi, num_views, endpoint=False)
 
 # Reconstruction parameters
 img_size = 256
-sharpness = 1.0
-T = 1.0
-p = 1.2
 snr_db = 40.0
+sharpness = 0.0
+T = 0.1
+p = 1.2
+
+# Multi-resolution works much better for limited and sparse view reconstruction
+max_resolutions=2 # Use 2 additional resolutions to do reconstruction
 
 # Generate phantom with a single slice
 phantom = svmbir.phantom.gen_shepp_logan(img_size,img_size)
@@ -29,7 +32,7 @@ phantom = np.expand_dims(phantom, axis=0)
 sino = svmbir.project(phantom, angles, num_channels, geometry=geometry, dist_source_detector=dist_source_detector, magnification=magnification, delta_channel=delta_channel)
 
 # Perform MBIR reconstruction
-recon = svmbir.recon(sino, angles, num_rows=img_size, num_cols=img_size, T=T, p=p, sharpness=sharpness, snr_db=snr_db, geometry=geometry, dist_source_detector=dist_source_detector, magnification=magnification, delta_channel=delta_channel)
+recon = svmbir.recon(sino, angles, num_rows=img_size, num_cols=img_size, T=T, p=p, sharpness=sharpness, snr_db=snr_db, geometry=geometry, dist_source_detector=dist_source_detector, magnification=magnification, delta_channel=delta_channel, max_resolutions = max_resolutions)
 
 # Compute Normalized Root Mean Squared Error
 nrmse = svmbir.phantom.nrmse(recon[0], phantom[0])

--- a/demo/demo_fanbeam.py
+++ b/demo/demo_fanbeam.py
@@ -42,12 +42,15 @@ vmin = 1.0
 vmax = 1.2
 plt.figure(); plt.imshow(phantom[0],vmin=vmin,vmax=vmax,cmap='gray'); plt.colorbar()
 plt.title('Shepp Logan Phantom')
+plt.savefig('output/shepp_logan_phantom.png')
 
 plt.figure(); plt.imshow(np.squeeze(sino).T,cmap='gray'); plt.colorbar()
 plt.title('Sinogram')
+plt.savefig('output/shepp_logan_sinogram.png')
 
 plt.figure(); plt.imshow(recon[0],vmin=vmin,vmax=vmax,cmap='gray'); plt.colorbar()
 plt.title(f'Reconstruction, nmrse={nrmse:.3f}')
+plt.savefig('output/shepp_logan_recon_fanbeam.png')
 
 print("Close figures to continue")
 plt.show()

--- a/demo/demo_multires_comparison.py
+++ b/demo/demo_multires_comparison.py
@@ -61,10 +61,10 @@ plot_image(phantom[display_slice], title='Shepp Logan Phantom', filename='output
 
 # display fixed resolution reconstruction
 title = f'Slice {display_slice:d} of Fixed Res Recon with NRMSE={nrmse:.3f}.'
-plot_image(recon[display_slice], title=title, filename='output/mr_3D_microscopy_recon.png', vmin=vmin, vmax=vmax)
+plot_image(recon[display_slice], title=title, filename='output/fixed_res_3D_microscopy_recon.png', vmin=vmin, vmax=vmax)
 
 # display multi-resolution reconstruction
 title = f'Slice {display_slice:d} of Multi-Res Recon with NRMSE={mr_nrmse:.3f}.'
-plot_image(mr_recon[display_slice], title=title, filename='output/mr_3D_microscopy_recon.png', vmin=vmin, vmax=vmax)
+plot_image(mr_recon[display_slice], title=title, filename='output/multi_res_3D_microscopy_recon.png', vmin=vmin, vmax=vmax)
 
 input("press Enter")

--- a/demo/demo_multires_comparison.py
+++ b/demo/demo_multires_comparison.py
@@ -19,9 +19,9 @@ num_views = 64
 tilt_angle = np.pi/3 # Tilt range of +-60deg
 
 # Reconstruction parameters
-sharpness = 2.0
+snr_db = 40.0
+sharpness = 0.0
 T = 0.25
-snr_db = 30.0
 p = 1.2
 
 # Multi-resolution works much better for limited and sparse view reconstruction
@@ -65,6 +65,6 @@ plot_image(recon[display_slice], title=title, filename='output/mr_3D_microscopy_
 
 # display multi-resolution reconstruction
 title = f'Slice {display_slice:d} of Multi-Res Recon with NRMSE={mr_nrmse:.3f}.'
-plot_image(recon[display_slice], title=title, filename='output/mr_3D_microscopy_recon.png', vmin=vmin, vmax=vmax)
+plot_image(mr_recon[display_slice], title=title, filename='output/mr_3D_microscopy_recon.png', vmin=vmin, vmax=vmax)
 
 input("press Enter")

--- a/demo/demo_prox.py
+++ b/demo/demo_prox.py
@@ -19,11 +19,11 @@ num_views = 144
 tilt_angle = np.pi/2 # Tilt range of +-90deg
 
 # Reconstruction parameters
-sigma_p = 0.2
 snr_db = 40.0
+sigma_p = 0.2
 
 # Multi-resolution works much better for limited and sparse view reconstruction
-max_resolutions=1 # Use 2 additional resolutions to do reconstruction
+max_resolutions=1 # Use 1 additional resolution to do reconstruction
 
 # Display parameters
 vmin = 1.0


### PR DESCRIPTION
I updated the parameter values for the demos so that:
- They are all the same
- They yield consistent image quality
- They all use 2 levels of multi-resolution (except the prox demo)
