### PR TITLE
modified default values for snr_db and magnification

### DIFF
--- a/demo/demo_3D_microscopy.py
+++ b/demo/demo_3D_microscopy.py
@@ -24,9 +24,6 @@ sharpness = 0.0
 T = 0.25
 p = 1.2
 
-# Multi-resolution works much better for limited and sparse view reconstruction
-max_resolutions=2 # Use 2 additional resolutions to do reconstruction
-
 # Display parameters
 vmin = 0.0
 vmax = 1.1
@@ -44,7 +41,7 @@ sino = svmbir.project(phantom, angles, max(num_rows, num_cols))
 (num_views, num_slices, num_channels) = sino.shape
 
 # Perform MBIR reconstruction
-recon = svmbir.recon(sino, angles, num_rows=num_rows, num_cols=num_cols, max_resolutions=max_resolutions, T=T, p=p, sharpness=sharpness, snr_db=snr_db )
+recon = svmbir.recon(sino, angles, num_rows=num_rows, num_cols=num_cols, T=T, p=p, sharpness=sharpness, snr_db=snr_db )
 
 # Compute Normalized Root Mean Squared Error
 nrmse = svmbir.phantom.nrmse(recon, phantom)

--- a/demo/demo_3D_shepp_logan.py
+++ b/demo/demo_3D_shepp_logan.py
@@ -23,9 +23,6 @@ sharpness = 0.0
 T = 0.1
 p = 1.2
 
-# Multi-resolution works much better for limited and sparse view reconstruction
-max_resolutions=2 # Use 2 additional resolutions to do reconstruction
-
 # Display parameters
 vmin = 1.0
 vmax = 1.2
@@ -43,7 +40,7 @@ sino = svmbir.project(phantom, angles, num_rows_cols )
 (num_views, num_slices, num_channels) = sino.shape
 
 # Perform fixed resolution MBIR reconstruction
-recon = svmbir.recon(sino, angles, T=T, p=p, sharpness=sharpness, snr_db=snr_db, max_resolutions = max_resolutions)
+recon = svmbir.recon(sino, angles, T=T, p=p, sharpness=sharpness, snr_db=snr_db)
 
 # Compute Normalized Root Mean Squared Error
 nrmse = svmbir.phantom.nrmse(recon, phantom)

--- a/demo/demo_fanbeam.py
+++ b/demo/demo_fanbeam.py
@@ -23,16 +23,13 @@ sharpness = 0.0
 T = 0.1
 p = 1.2
 
-# Multi-resolution works much better for limited and sparse view reconstruction
-max_resolutions=2 # Use 2 additional resolutions to do reconstruction
-
 # Generate phantom with a single slice
 phantom = svmbir.phantom.gen_shepp_logan(img_size,img_size)
 phantom = np.expand_dims(phantom, axis=0)
 sino = svmbir.project(phantom, angles, num_channels, geometry=geometry, dist_source_detector=dist_source_detector, magnification=magnification, delta_channel=delta_channel)
 
 # Perform MBIR reconstruction
-recon = svmbir.recon(sino, angles, num_rows=img_size, num_cols=img_size, T=T, p=p, sharpness=sharpness, snr_db=snr_db, geometry=geometry, dist_source_detector=dist_source_detector, magnification=magnification, delta_channel=delta_channel, max_resolutions = max_resolutions)
+recon = svmbir.recon(sino, angles, num_rows=img_size, num_cols=img_size, T=T, p=p, sharpness=sharpness, snr_db=snr_db, geometry=geometry, dist_source_detector=dist_source_detector, magnification=magnification, delta_channel=delta_channel)
 
 # Compute Normalized Root Mean Squared Error
 nrmse = svmbir.phantom.nrmse(recon[0], phantom[0])

--- a/demo/demo_multires_comparison.py
+++ b/demo/demo_multires_comparison.py
@@ -44,7 +44,7 @@ sino = svmbir.project(phantom, angles, max(num_rows, num_cols))
 (num_views, num_slices, num_channels) = sino.shape
 
 # Perform fixed resolution MBIR reconstruction
-recon = svmbir.recon(sino, angles, num_rows=num_rows, num_cols=num_cols, T=T, p=p, sharpness=sharpness, snr_db=snr_db )
+recon = svmbir.recon(sino, angles, num_rows=num_rows, num_cols=num_cols, T=T, p=p, max_resolutions=0, sharpness=sharpness, snr_db=snr_db )
 
 # Perform multi-resolution MBIR reconstruction
 mr_recon = svmbir.recon(sino, angles, num_rows=num_rows, num_cols=num_cols, T=T, p=p, max_resolutions=max_resolutions, sharpness=sharpness, snr_db=snr_db )

--- a/demo/demo_prox.py
+++ b/demo/demo_prox.py
@@ -45,7 +45,7 @@ sino = svmbir.project(phantom, angles, num_rows_cols )
 phantom_rot = np.swapaxes(phantom, 1, 2)
 
 # Perform fixed resolution MBIR reconstruction using proximal map input
-recon = svmbir.recon(sino, angles, max_resolutions=max_resolutions, init_image=phantom_rot, prox_image=phantom_rot, positivity=False, sigma_p=sigma_p, snr_db=snr_db)
+recon = svmbir.recon(sino, angles, max_resolutions = max_resolutions, init_image=phantom_rot, prox_image=phantom_rot, positivity=False, sigma_p=sigma_p, snr_db=snr_db)
 
 # create output folder
 os.makedirs('output', exist_ok=True)

--- a/demo/demo_prox.py
+++ b/demo/demo_prox.py
@@ -22,9 +22,6 @@ tilt_angle = np.pi/2 # Tilt range of +-90deg
 snr_db = 40.0
 sigma_p = 0.2
 
-# Multi-resolution works much better for limited and sparse view reconstruction
-max_resolutions=1 # Use 1 additional resolution to do reconstruction
-
 # Display parameters
 vmin = 1.0
 vmax = 1.2
@@ -45,7 +42,7 @@ sino = svmbir.project(phantom, angles, num_rows_cols )
 phantom_rot = np.swapaxes(phantom, 1, 2)
 
 # Perform fixed resolution MBIR reconstruction using proximal map input
-recon = svmbir.recon(sino, angles, max_resolutions = max_resolutions, init_image=phantom_rot, prox_image=phantom_rot, positivity=False, sigma_p=sigma_p, snr_db=snr_db)
+recon = svmbir.recon(sino, angles, init_image=phantom_rot, prox_image=phantom_rot, positivity=False, sigma_p=sigma_p, snr_db=snr_db)
 
 # create output folder
 os.makedirs('output', exist_ok=True)

--- a/svmbir/_utils.py
+++ b/svmbir/_utils.py
@@ -120,9 +120,9 @@ def test_args_recon(sharpness, positivity, relax_factor, max_resolutions, stop_t
         warnings.warn("Parameter relax_factor is not valid float; Setting to 1.0.")
         relax_factor = 1.0
 
-    if not (isinstance(max_resolutions, int) and (max_resolutions >= 0)):
-        warnings.warn("Parameter max_resolutions is not valid int; Setting max_resolutions = 0.")
-        max_resolutions = 0
+    if not ((isinstance(max_resolutions, int) and (max_resolutions >= 0)) or (max_resolutions is None)):
+        warnings.warn("Parameter max_resolutions is not valid int; Setting max_resolutions = None.")
+        max_resolutions = None
 
     if isinstance(stop_threshold,int):
         stop_threshold = float(stop_threshold)

--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -105,9 +105,9 @@ def auto_max_resolutions(init_image) :
     """Compute the automatic value of ``max_resolutions`` for use in MBIR reconstruction.
 
     Args:
-        init_image (float): Initial value of reconstruction image
+        init_image (ndarray): Initial image for reconstruction.
     Returns:
-        ndarray: Automatic value of ``max_resolutions``.
+        int: Automatic value of ``max_resolutions``.
     """
     # Default value of max_resolutions
     max_resolutions = 2
@@ -284,9 +284,9 @@ def recon(sino, angles,
             [Default='parallel'] Scanner geometry: 'parallel', 'fan-curved', or 'fan-flat'. Note for fan geometries
             the ``dist_source_detector`` and ``magnification`` arguments must be specified.
         dist_source_detector (float):
-            (Required, 'fan' geometry only) Distance from X-ray focal spot to detectors, in :math:`ALU`.
-        magnification (float): [Default=None]
-            (Required, 'fan' geometry only) Magnification factor = dist_source_detector/dist_source_isocenter.
+            (Required for fan beam geometries only) Distance from X-ray focal spot to detectors, in :math:`ALU`.
+        magnification (float):
+            (Required for fan beam geometries only) Magnification factor = dist_source_detector/dist_source_isocenter.
         weights (ndarray, optional): [Default=None] 3D weights array with same shape as sino.
         weight_type (string, optional): [Default="unweighted"] Type of noise model used for data.
             If the ``weights`` array is not supplied, then the function ``svmbir.calc_weights`` is 
@@ -309,9 +309,9 @@ def recon(sino, angles,
             If None, automatically set with auto_roi_radius().
             Pixels outside the radius roi_radius in the :math:`(x,y)` plane are disregarded in the reconstruction.
         delta_channel (float, optional): [Default=1.0] Scalar value of detector channel spacing in :math:`ALU`.
-        delta_pixel (float, optional): Scalar value of the spacing between image pixels in the 2D slice 
-            plane in :math:`ALU`. Defaults to ``delta_channel`` for ``parallel`` beam geometry, 
-            and ``delta_channel``/``magnification`` for fanbeam geometries.
+        delta_pixel (float, optional): Scalar value of the spacing between image pixels in the 2D slice
+            plane in :math:`ALU`. Defaults to ``delta_channel`` for ``parallel`` beam geometry,
+            and ``delta_channel``/``magnification`` for fan beam geometries.
         center_offset (float, optional): [Default=0.0] Scalar value of offset from center-of-rotation.
         sigma_y (float, optional): [Default=None] Scalar value of noise standard deviation parameter.
             If None, automatically set with auto_sigma_y.
@@ -389,7 +389,7 @@ def recon(sino, angles,
         magnification = 1.0
     elif geometry=='fan-curved' or geometry=='fan-flat':
         if dist_source_detector is None or magnification is None:
-            raise Exception('For fanbeam geometries, need to specify dist_source_detector and magnification')
+            raise Exception('For fan beam geometries, need to specify dist_source_detector and magnification')
     elif geometry=='fan':
         raise Exception("Ambiguous geometry 'fan': Please specify 'fan-curved' or 'fan-flat'")
     else:
@@ -450,9 +450,9 @@ def recon(sino, angles,
 
 
 
-def project(image, angles, num_channels, geometry = 'parallel',
+def project(image, angles, num_channels,
+            geometry = 'parallel', dist_source_detector = None, magnification = None,
             delta_channel = 1.0, delta_pixel = None, center_offset = 0.0, roi_radius = None,
-            dist_source_detector = None, magnification = None,
             num_threads = None, svmbir_lib_path = __svmbir_lib_path, delete_temps = True,
             object_name = 'object', verbose = 1):
     """project(image, angles, num_channels, geometry = 'parallel', **kwargs)
@@ -470,21 +470,21 @@ def project(image, angles, num_channels, geometry = 'parallel',
         num_channels (int):
             Number of sinogram channels.
         geometry (string):
-            [Default='parallel'] Scanner geometry, either 'parallel' or 'fan'. Note for fan geometry
+            [Default='parallel'] Scanner geometry: 'parallel', 'fan-curved', or 'fan-flat'. Note for fan geometries
             the ``dist_source_detector`` and ``magnification`` arguments must be specified.
+        dist_source_detector (float):
+            (Required for fan beam geometries only) Distance from X-ray focal spot to detectors, in :math:`ALU`.
+        magnification (float):
+            (Required for fan beam geometries only) Magnification factor = dist_source_detector/dist_source_isocenter.
         delta_channel (float, optional): [Default=1.0] Scalar value of detector channel spacing in :math:`ALU`.
         delta_pixel (float, optional): Scalar value of the spacing between image pixels in the 2D slice 
             plane in :math:`ALU`. Defaults to ``delta_channel`` for ``parallel`` beam geometry, 
-            and ``delta_channel``/``magnification`` for ``fan`` geometry.
+            and ``delta_channel``/``magnification`` for fan beam geometries.
         center_offset (float, optional):
             [Default=0.0] Offset from center-of-rotation in 'fractional number of channels' units.
         roi_radius (float, optional): [Default=None] Radius of relevant image region in :math:`ALU`.
             Pixels outside the radius are disregarded in the forward projection.
             If not given, the value is set with auto_roi_radius().
-        dist_source_detector (float):
-            (Required, fanbeam geometries only) Distance from X-ray focal spot to detectors, in :math:`ALU`.
-        magnification (float):
-            (Required, fanbeam geometries only) Magnification factor = dist_source_detector/dist_source_isocenter.
         num_threads (int, optional): [Default=None] Number of compute threads requested when executed.
             If None, num_threads is set to the number of cores in the system.
         svmbir_lib_path (string, optional):
@@ -529,7 +529,7 @@ def project(image, angles, num_channels, geometry = 'parallel',
         magnification = 1.0
     elif geometry=='fan-curved' or geometry=='fan-flat':
         if dist_source_detector is None or magnification is None:
-            raise Exception('For fanbeam geometries, need to specify dist_source_detector and magnification')
+            raise Exception('For fan beam geometries, need to specify dist_source_detector and magnification')
     elif geometry=='fan':
         raise Exception("Ambiguous geometry 'fan': Please specify 'fan-curved' or 'fan-flat'")
     else:
@@ -565,12 +565,12 @@ def project(image, angles, num_channels, geometry = 'parallel',
     return proj
 
 
-def backproject(sino, angles, geometry = 'parallel', num_rows=None, num_cols=None,
-            dist_source_detector = None, magnification = None,
+def backproject(sino, angles, num_rows=None, num_cols=None,
+            geometry = 'parallel', dist_source_detector = None, magnification = None,
             delta_channel = 1.0, delta_pixel = None, center_offset = 0.0, roi_radius = None,
             num_threads = None, svmbir_lib_path = __svmbir_lib_path, delete_temps = True,
             object_name = 'object', verbose = 1):
-    """backproject(sino, angles, geometry = 'parallel', **kwargs)
+    """backproject(sino, angles, **kwargs)
 
     Compute 3D back-projection.
 
@@ -580,23 +580,22 @@ def backproject(sino, angles, geometry = 'parallel', num_rows=None, num_cols=Non
         angles (ndarray):
             1D numpy array of view angles in radians.
             'angles[k]' is the angle in radians for view :math:`k`.
-        geometry (string):
-            [Default='parallel'] Scanner geometry: 'parallel', 'fan-curved', or 'fan-flat'. Note for fan geometries
-            the ``dist_source_detector`` and ``magnification`` arguments must be specified.
         num_rows (int, optional):
             [Default=num_channels] Integer number of output image rows.
         num_cols (int, optional):
             [Default=num_channels] Integer number of output image columns.
+        geometry (string):
+            [Default='parallel'] Scanner geometry: 'parallel', 'fan-curved', or 'fan-flat'. Note for fan geometries
+            the ``dist_source_detector`` and ``magnification`` arguments must be specified.
         dist_source_detector (float):
-            (Required, fanbeam geometries only) Distance from X-ray focal spot to detectors, in :math:`ALU`.
+            (Required for fan beam geometries only) Distance from X-ray focal spot to detectors, in :math:`ALU`.
         magnification (float):
-            (Required, fanbeam geometries only) Magnification factor = dist_source_detector/dist_source_isocenter.
+            (Required for fan beam geometries only) Magnification factor = dist_source_detector/dist_source_isocenter.
         delta_channel (float, optional):
             [Default=1.0] Detector channel spacing in :math:`ALU`.
-        delta_pixel (float, optional):
-            Size of image pixels in the 2D slice plane in :math:`ALU`.
-            Defaults to ``delta_channel`` for ``parallel`` beam geometry, 
-            and ``delta_channel``/``magnification`` for fanbeam geometries.
+        delta_pixel (float, optional): Scalar value of the spacing between image pixels in the 2D slice 
+            plane in :math:`ALU`. Defaults to ``delta_channel`` for ``parallel`` beam geometry, 
+            and ``delta_channel``/``magnification`` for fan beam geometries.
         center_offset (float, optional):
             [Default=0.0] Offset from center-of-rotation in 'fractional number of channels' units.
         roi_radius (float, optional): [Default=None] Radius of relevant image region in :math:`ALU`.
@@ -639,7 +638,7 @@ def backproject(sino, angles, geometry = 'parallel', num_rows=None, num_cols=Non
         magnification = 1.0
     elif geometry=='fan-curved' or geometry=='fan-flat':
         if dist_source_detector is None or magnification is None:
-            raise Exception('For fanbeam geometries, need to specify dist_source_detector and magnification')
+            raise Exception('For fan beam geometries, need to specify dist_source_detector and magnification')
     elif geometry=='fan':
         raise Exception("Ambiguous geometry 'fan': Please specify 'fan-curved' or 'fan-flat'")
     else:

--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -101,12 +101,11 @@ def calc_weights(sino, weight_type ):
     return weights
 
 
-def auto_max_resolutions(init_image, prox_image ) :
+def auto_max_resolutions(init_image) :
     """Compute the automatic value of ``max_resolutions`` for use in MBIR reconstruction.
 
     Args:
         init_image (float): Initial value of reconstruction image
-        prox_image (ndarray): 3D proximal map input image.
     Returns:
         ndarray: Automatic value of ``max_resolutions``.
     """
@@ -114,10 +113,6 @@ def auto_max_resolutions(init_image, prox_image ) :
     max_resolutions = 2
     if isinstance(init_image, np.ndarray) and (init_image.ndim == 3):
         #print('Init image present. Setting max_resolutions = 0.')
-        max_resolutions = 0
-
-    if isinstance(prox_image, np.ndarray) and (prox_image.ndim == 3):
-        #print('Prox image present. Setting max_resolutions = 0.')
         max_resolutions = 0
 
     return max_resolutions
@@ -402,7 +397,7 @@ def recon(sino, angles,
 
     # Set automatic value of max_resolutions
     if max_resolutions is None :
-        max_resolutions = auto_max_resolutions(init_image, prox_image)
+        max_resolutions = auto_max_resolutions(init_image)
 
     # Set automatic values of num_rows, num_cols, and roi_radius
     if delta_pixel is None:

--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -8,20 +8,21 @@ import numpy as np
 import os
 import svmbir._utils as utils
 
-if os.environ.get('CLIB') =='CMD_LINE':
+if os.environ.get('CLIB') == 'CMD_LINE' :
     import svmbir.interface_py_c as ci
-else:
+else :
     import svmbir.interface_cy_c as ci
 
 __svmbir_lib_path = os.path.join(os.path.expanduser('~'), '.cache', 'svmbir')
 
-def _svmbir_lib_path():
+
+def _svmbir_lib_path() :
     """Returns the path to the cache directory used by svmbir
     """
     return __svmbir_lib_path
 
 
-def _clear_cache(svmbir_lib_path = __svmbir_lib_path):
+def _clear_cache( svmbir_lib_path = __svmbir_lib_path ) :
     """Clear the cache files used by svmbir.
 
     Args:
@@ -30,7 +31,7 @@ def _clear_cache(svmbir_lib_path = __svmbir_lib_path):
     shutil.rmtree(svmbir_lib_path)
 
 
-def sino_sort(sino, angles, weights=None):
+def sino_sort( sino, angles, weights = None ) :
     r"""Sort sinogram views (and sinogram weights if provided) so that view angles are in monotonically increasing order on the interval :math:`[0,2\pi)`.
         This function can be used to preprocess the sinogram data so that svmbir reconstruction is faster.
         The function may create additional arrays that increase memory usage.
@@ -48,24 +49,24 @@ def sino_sort(sino, angles, weights=None):
     """
 
     # Wrap the view angles modulo 2pi and sort
-    angles = np.mod(angles, 2*np.pi)
+    angles = np.mod(angles, 2 * np.pi)
     sorted_indices = np.argsort(angles)
 
     # Sort sino, angles, and weights (if any) to be in monotone increasing order
     sino = np.array(sino)[sorted_indices]
-    sino = np.ascontiguousarray(sino) # ensure views are in sorted order in memory
+    sino = np.ascontiguousarray(sino)  # ensure views are in sorted order in memory
     angles = angles[sorted_indices]
     angles = np.ascontiguousarray(angles)
 
-    if weights is None:
+    if weights is None :
         return sino, angles
-    else:
+    else :
         weights = np.array(weights)[sorted_indices]
         weights = np.ascontiguousarray(weights)
         return sino, angles, weights
 
 
-def calc_weights(sino, weight_type ):
+def calc_weights( sino, weight_type ) :
     """Compute the weights used in MBIR reconstruction.
 
     Args:
@@ -93,14 +94,36 @@ def calc_weights(sino, weight_type ):
     elif weight_type == 'transmission_root' :
         weights = np.exp(-sino / 2)
     elif weight_type == 'emission' :
-        weights = 1 / (np.absolute(sino)  + 0.1)
+        weights = 1 / (np.absolute(sino) + 0.1)
     else :
         raise Exception("calc_weights: undefined weight_type {}".format(weight_type))
 
     return weights
 
 
-def auto_sigma_y(sino, weights, snr_db = 40.0, delta_pixel = 1.0, delta_channel = 1.0):
+def auto_max_resolutions(init_image, prox_image ) :
+    """Compute the automatic value of ``max_resolutions`` for use in MBIR reconstruction.
+
+    Args:
+        init_image (float): Initial value of reconstruction image
+        prox_image (ndarray): 3D proximal map input image.
+    Returns:
+        ndarray: Automatic value of ``max_resolutions``.
+    """
+    # Default value of max_resolutions
+    max_resolutions = 2
+    if isinstance(init_image, np.ndarray) and (init_image.ndim == 3):
+        #print('Init image present. Setting max_resolutions = 0.')
+        max_resolutions = 0
+
+    if isinstance(prox_image, np.ndarray) and (prox_image.ndim == 3):
+        #print('Prox image present. Setting max_resolutions = 0.')
+        max_resolutions = 0
+
+    return max_resolutions
+
+
+def auto_sigma_y( sino, weights, snr_db = 40.0, delta_pixel = 1.0, delta_channel = 1.0 ) :
     """Compute the automatic value of ``sigma_y`` for use in MBIR reconstruction.
 
     Args:
@@ -115,7 +138,6 @@ def auto_sigma_y(sino, weights, snr_db = 40.0, delta_pixel = 1.0, delta_channel 
             [Default=1.0] Scalar value of pixel spacing in :math:`ALU`.
         delta_channel (float, optional):
             [Default=1.0] Scalar value of detector channel spacing in :math:`ALU`.
-
 
     Returns:
         ndarray: Automatic values of regularization parameter.
@@ -132,13 +154,13 @@ def auto_sigma_y(sino, weights, snr_db = 40.0, delta_pixel = 1.0, delta_channel 
     # compute sigma_y and scale by relative pixel and detector pitch
     sigma_y = rel_noise_std * signal_rms * (delta_pixel / delta_channel) ** (0.5)
 
-    if sigma_y > 0:
+    if sigma_y > 0 :
         return sigma_y
-    else:
+    else :
         return 1.0
 
 
-def auto_sigma_x(sino, delta_channel = 1.0, sharpness = 0.0 ):
+def auto_sigma_x( sino, delta_channel = 1.0, sharpness = 0.0 ) :
     """Compute the automatic value of ``sigma_x`` for use in MBIR reconstruction.
 
     Args:
@@ -156,7 +178,7 @@ def auto_sigma_x(sino, delta_channel = 1.0, sharpness = 0.0 ):
     return 0.2 * auto_sigma_prior(sino, delta_channel, sharpness)
 
 
-def auto_sigma_p(sino, delta_channel = 1.0, sharpness = 0.0 ):
+def auto_sigma_p( sino, delta_channel = 1.0, sharpness = 0.0 ) :
     """Compute the automatic value of ``sigma_p`` for use in proximal map estimation.
 
     Args:
@@ -174,7 +196,7 @@ def auto_sigma_p(sino, delta_channel = 1.0, sharpness = 0.0 ):
     return 1.0 * auto_sigma_prior(sino, delta_channel, sharpness)
 
 
-def auto_sigma_prior(sino, delta_channel = 1.0, sharpness = 0.0 ):
+def auto_sigma_prior( sino, delta_channel = 1.0, sharpness = 0.0 ) :
     """Compute the automatic value of prior model regularization term for use in MBIR reconstruction or proximal map estimation. This subroutine is called by ``auto_sigma_x`` in MBIR reconstruction, or ``auto_sigma_p`` in proximal map estimation.
 
     Args:
@@ -203,29 +225,29 @@ def auto_sigma_prior(sino, delta_channel = 1.0, sharpness = 0.0 ):
     return sigma_prior
 
 
-def auto_img_size(geometry, num_channels, delta_channel, delta_pixel, magnification=1.0):
+def auto_img_size( geometry, num_channels, delta_channel, delta_pixel, magnification = 1.0 ) :
     "Compute the default image size"
 
-    if geometry == 'parallel':
+    if geometry == 'parallel' :
         num_rows = int(np.ceil(num_channels * delta_channel / delta_pixel))
-    elif geometry == 'fan':
-        num_rows = int(np.ceil(num_channels * delta_channel / (delta_pixel*magnification) ))
-    else:
+    elif geometry == 'fan' :
+        num_rows = int(np.ceil(num_channels * delta_channel / (delta_pixel * magnification)))
+    else :
         raise Exception('Unrecognized geometry {}'.format(geometry))
 
     num_cols = num_rows
-    return num_rows,num_cols
+    return num_rows, num_cols
 
 
-def auto_roi_radius(delta_pixel, num_rows, num_cols):
+def auto_roi_radius( delta_pixel, num_rows, num_cols ) :
     """Compute the automatic value of ``roi_radius``.
        Chosen so that it inscribes the largest axis of the recon image.
     """
-    roi_radius = float(delta_pixel * max(num_rows, num_cols))/2.0
+    roi_radius = float(delta_pixel * max(num_rows, num_cols)) / 2.0
     return roi_radius
 
 
-def max_threads(num_threads, num_slices, num_rows, num_cols, positivity = True):
+def max_threads( num_threads, num_slices, num_rows, num_cols, positivity = True ) :
     """Compute the maximum recommended number of threads for stable convergence.
 
     Args:
@@ -243,25 +265,26 @@ def max_threads(num_threads, num_slices, num_rows, num_cols, positivity = True):
     super_voxel_width = 16
 
     # compute number of possible super-voxels
-    number_of_possible_SVs = ( num_slices * num_rows*num_cols) / super_voxel_width**2
+    number_of_possible_SVs = (num_slices * num_rows * num_cols) / super_voxel_width ** 2
 
     # Set the maximum number of allowed threads
-    max_threads = int( np.ceil( number_of_possible_SVs / ( (avg_SV_dist)**2 ) ) )
-    if ( (num_threads > max_threads) and (positivity is False) ):
+    max_threads = int(np.ceil(number_of_possible_SVs / ((avg_SV_dist) ** 2)))
+    if ((num_threads > max_threads) and (positivity is False)) :
         num_threads = max_threads
-        print("Warning: Reducing the number of threads to ",num_threads)
+        print("Warning: Reducing the number of threads to ", num_threads)
     return num_threads
 
 
-def recon(sino, angles,
-          geometry = 'parallel', dist_source_detector = None, magnification = 1.0,
-          weights = None, weight_type = 'unweighted', init_image = 0.0, prox_image = None, init_proj = None,
-          num_rows = None, num_cols = None, roi_radius = None,
-          delta_channel = 1.0, delta_pixel = None, center_offset = 0.0,
-          sigma_y = None, snr_db = 40.0, sigma_x = None, sigma_p = None, p = 1.2, q = 2.0, T = 1.0, b_interslice = 1.0,
-          sharpness = 0.0, positivity = True, relax_factor=1.0, max_resolutions = 2, stop_threshold = 0.02, max_iterations = 100,
-          num_threads = None, delete_temps = True, svmbir_lib_path = __svmbir_lib_path, object_name = 'object',
-          verbose = 1) :
+def recon( sino, angles,
+           geometry = 'parallel', dist_source_detector = None, magnification = 1.0,
+           weights = None, weight_type = 'unweighted', init_image = 0.0, prox_image = None, init_proj = None,
+           num_rows = None, num_cols = None, roi_radius = None,
+           delta_channel = 1.0, delta_pixel = None, center_offset = 0.0,
+           sigma_y = None, snr_db = 40.0, sigma_x = None, sigma_p = None, p = 1.2, q = 2.0, T = 1.0, b_interslice = 1.0,
+           sharpness = 0.0, positivity = True, relax_factor = 1.0, max_resolutions = None, stop_threshold = 0.02,
+           max_iterations = 100,
+           num_threads = None, delete_temps = True, svmbir_lib_path = __svmbir_lib_path, object_name = 'object',
+           verbose = 1 ) :
     """recon(sino, angles, geometry = 'parallel', **kwargs)
 
     Compute 3D MBIR reconstruction using multi-resolution SVMBIR algorithm.
@@ -329,8 +352,9 @@ def recon(sino, angles,
             when used in applications that can generate negative image values.
         relax_factor (float, optional): [Default=1.0] Relaxation factor for pixel update. Valid range (0,2.0].
             Values in (0,1) produce under-relaxation (smaller step size); Values in (1,2] produce over-relaxation.
-        max_resolutions (int, optional): [Default=2] Integer >=0 that specifies the maximum number of grid
+        max_resolutions (int, optional): [Default=None] Integer >=0 that specifies the maximum number of grid
             resolutions used to solve MBIR reconstruction problem.
+            If None, automatically set with auto_max_resolutions.
         stop_threshold (float, optional): [Default=0.02] Scalar valued stopping threshold in percent.
             If stop_threshold=0.0, then run max iterations.
         max_iterations (int, optional): [Default=100] Integer valued specifying the maximum number of 
@@ -357,83 +381,95 @@ def recon(sino, angles,
 
     # Test for valid sino and angles structure. If sino is 2D, make it 3D
     angles = utils.test_args_angles(angles)
-    sino = utils.test_args_sino(sino,angles)
+    sino = utils.test_args_sino(sino, angles)
     (num_views, num_slices, num_channels) = sino.shape
 
     # Tests parameters for valid types and values; print warnings if necessary; and return default values.
-    num_rows, num_cols, delta_pixel, roi_radius, delta_channel, center_offset = utils.test_args_geom(num_rows, num_cols, delta_pixel, roi_radius, delta_channel, center_offset)
-    sharpness, positivity, relax_factor, max_resolutions, stop_threshold, max_iterations = utils.test_args_recon(sharpness, positivity, relax_factor, max_resolutions, stop_threshold, max_iterations)
-    init_image, prox_image, init_proj, weights, weight_type = utils.test_args_inits(init_image, prox_image, init_proj, weights, weight_type)
+    num_rows, num_cols, delta_pixel, roi_radius, delta_channel, center_offset = utils.test_args_geom(
+        num_rows, num_cols, delta_pixel, roi_radius, delta_channel, center_offset)
+    sharpness, positivity, relax_factor, max_resolutions, stop_threshold, max_iterations = utils.test_args_recon(
+        sharpness, positivity, relax_factor, max_resolutions, stop_threshold, max_iterations)
+    init_image, prox_image, init_proj, weights, weight_type = utils.test_args_inits(
+        init_image, prox_image, init_proj, weights, weight_type)
     sigma_y, snr_db, sigma_x, sigma_p = utils.test_args_noise(sigma_y, snr_db, sigma_x, sigma_p)
     p, q, T, b_interslice = utils.test_args_qggmrf(p, q, T, b_interslice)
     num_threads, delete_temps, verbose = utils.test_args_sys(num_threads, delete_temps, verbose)
 
     # Geometry dependent settings
-    if geometry == 'parallel':
+    if geometry == 'parallel' :
         dist_source_detector = 0.0
         magnification = 1.0
-    elif geometry == 'fan':
-        if dist_source_detector is None:
+    elif geometry == 'fan' :
+        if dist_source_detector is None :
             raise Exception('For fanbeam geometry, need to specify dist_source_detector')
-    else:
+    else :
         raise Exception('Unrecognized geometry {}'.format(geometry))
 
+    # Set automatic value of max_resolutions
+    if max_resolutions is None :
+        max_resolutions = auto_max_resolutions(init_image, prox_image)
+
     # Set automatic values of num_rows, num_cols, and roi_radius
-    if delta_pixel is None:
-        delta_pixel = delta_channel/magnification
-    if num_rows is None:
-        num_rows,_ = auto_img_size(geometry, num_channels, delta_channel, delta_pixel, magnification)
-    if num_cols is None:
-        _,num_cols = auto_img_size(geometry, num_channels, delta_channel, delta_pixel, magnification)
-    if roi_radius is None:
+    if delta_pixel is None :
+        delta_pixel = delta_channel / magnification
+    if num_rows is None :
+        num_rows, _ = auto_img_size(geometry, num_channels, delta_channel, delta_pixel, magnification)
+    if num_cols is None :
+        _, num_cols = auto_img_size(geometry, num_channels, delta_channel, delta_pixel, magnification)
+    if roi_radius is None :
         roi_radius = auto_roi_radius(delta_pixel, num_rows, num_cols)
 
     # Set automatic values for weights
-    if weights is None:
+    if weights is None :
         weights = calc_weights(sino, weight_type)
 
     # Set automatic value of sigma_y
-    if sigma_y is None:
+    if sigma_y is None :
         sigma_y = auto_sigma_y(sino, weights, snr_db, delta_pixel=delta_pixel, delta_channel=delta_channel)
 
     # Set automatic value of sigma_x
     # if qGGMRF mode, then set sigma_x either using the provided value by user, or with auto_sigma_x
-    if prox_image is None:
-        if sigma_x is None:
+    if prox_image is None :
+        if sigma_x is None :
             sigma_x = auto_sigma_x(sino, delta_channel, sharpness)
     # if proximal map mode, then overwrite sigma_x with sigma_p
-    else:
-        if sigma_p is None:
+    else :
+        if sigma_p is None :
             sigma_p = auto_sigma_p(sino, delta_channel, sharpness)
         sigma_x = sigma_p
 
     # Reduce num_threads for positivity=False if problems size calls for it
-    #num_threads_max = max_threads(num_threads, num_slices, num_rows, num_cols, positivity=positivity)
-    #if num_threads_max < num_threads:
+    # num_threads_max = max_threads(num_threads, num_slices, num_rows, num_cols, positivity=positivity)
+    # if num_threads_max < num_threads:
     #    num_threads = num_threads_max
     os.environ['OMP_NUM_THREADS'] = str(num_threads)
     os.environ['OMP_DYNAMIC'] = 'true'
 
     reconstruction = ci.multires_recon(sino=sino, angles=angles, weights=weights, weight_type=weight_type,
-                                       geometry=geometry, dist_source_detector=dist_source_detector, magnification=magnification,
+                                       geometry=geometry, dist_source_detector=dist_source_detector,
+                                       magnification=magnification,
                                        init_image=init_image, prox_image=prox_image, init_proj=init_proj,
                                        num_rows=num_rows, num_cols=num_cols, roi_radius=roi_radius,
-                                       delta_channel=delta_channel, delta_pixel=delta_pixel, center_offset=center_offset,
-                                       sigma_y=sigma_y, snr_db=snr_db, sigma_x=sigma_x, p=p, q=q, T=T, b_interslice=b_interslice,
-                                       sharpness=sharpness, positivity=positivity, relax_factor=relax_factor, max_resolutions=max_resolutions,
-                                       stop_threshold=stop_threshold, max_iterations=max_iterations, num_threads=num_threads,
-                                       delete_temps=delete_temps, svmbir_lib_path=svmbir_lib_path, object_name=object_name,
+                                       delta_channel=delta_channel, delta_pixel=delta_pixel,
+                                       center_offset=center_offset,
+                                       sigma_y=sigma_y, snr_db=snr_db, sigma_x=sigma_x, p=p, q=q, T=T,
+                                       b_interslice=b_interslice,
+                                       sharpness=sharpness, positivity=positivity, relax_factor=relax_factor,
+                                       max_resolutions=max_resolutions,
+                                       stop_threshold=stop_threshold, max_iterations=max_iterations,
+                                       num_threads=num_threads,
+                                       delete_temps=delete_temps, svmbir_lib_path=svmbir_lib_path,
+                                       object_name=object_name,
                                        verbose=verbose)
 
     return reconstruction
 
 
-
-def project(image, angles, num_channels, geometry = 'parallel',
-            delta_channel = 1.0, delta_pixel = None, center_offset = 0.0, roi_radius = None,
-            dist_source_detector = None, magnification = 1.0,
-            num_threads = None, svmbir_lib_path = __svmbir_lib_path, delete_temps = True,
-            object_name = 'object', verbose = 1):
+def project( image, angles, num_channels, geometry = 'parallel',
+             delta_channel = 1.0, delta_pixel = None, center_offset = 0.0, roi_radius = None,
+             dist_source_detector = None, magnification = 1.0,
+             num_threads = None, svmbir_lib_path = __svmbir_lib_path, delete_temps = True,
+             object_name = 'object', verbose = 1 ) :
     """project(image, angles, num_channels, geometry = 'parallel', **kwargs)
 
     Compute 3D forward-projection.
@@ -480,7 +516,7 @@ def project(image, angles, num_channels, geometry = 'parallel',
     """
 
     # Temporary check for argument order. From v0.2.4, order is project(image,angles,...)
-    if isinstance(image,np.ndarray) and isinstance(angles,np.ndarray) and (image.ndim < angles.ndim):
+    if isinstance(image, np.ndarray) and isinstance(angles, np.ndarray) and (image.ndim < angles.ndim) :
         print("WARNING: Check the argument order svmbir.project(image,angles,...)")
         print("**This is the order definition as of svmbir v0.2.4")
         print("**Swapping and proceeding...")
@@ -504,24 +540,25 @@ def project(image, angles, num_channels, geometry = 'parallel',
     num_views = len(angles)
 
     # Geometry dependent settings
-    if geometry == 'parallel':
+    if geometry == 'parallel' :
         dist_source_detector = 0.0
         magnification = 1.0
-    elif geometry == 'fan':
-        if dist_source_detector is None:
+    elif geometry == 'fan' :
+        if dist_source_detector is None :
             raise Exception('For fanbeam geometry, need to specify dist_source_detector')
-    else:
+    else :
         raise Exception('Unrecognized geometry {}'.format(geometry))
 
-    if delta_pixel is None:
-        delta_pixel = delta_channel/magnification
+    if delta_pixel is None :
+        delta_pixel = delta_channel / magnification
     if roi_radius is None :
         roi_radius = auto_roi_radius(delta_pixel, num_rows, num_cols)
 
     paths, sinoparams, imgparams = ci._init_geometry(angles, center_offset=center_offset,
                                                      geometry=geometry, dist_source_detector=dist_source_detector,
                                                      magnification=magnification,
-                                                     num_channels=num_channels, num_views=num_views, num_slices=num_slices,
+                                                     num_channels=num_channels, num_views=num_views,
+                                                     num_slices=num_slices,
                                                      num_rows=num_rows, num_cols=num_cols,
                                                      delta_channel=delta_channel, delta_pixel=delta_pixel,
                                                      roi_radius=roi_radius,
@@ -543,12 +580,11 @@ def project(image, angles, num_channels, geometry = 'parallel',
     return proj
 
 
-
-def backproject(sino, angles, geometry = 'parallel', num_rows=None, num_cols=None,
-            dist_source_detector = None, magnification = 1.0,
-            delta_channel = 1.0, delta_pixel = None, center_offset = 0.0, roi_radius = None,
-            num_threads = None, svmbir_lib_path = __svmbir_lib_path, delete_temps = True,
-            object_name = 'object', verbose = 1):
+def backproject( sino, angles, geometry = 'parallel', num_rows = None, num_cols = None,
+                 dist_source_detector = None, magnification = 1.0,
+                 delta_channel = 1.0, delta_pixel = None, center_offset = 0.0, roi_radius = None,
+                 num_threads = None, svmbir_lib_path = __svmbir_lib_path, delete_temps = True,
+                 object_name = 'object', verbose = 1 ) :
     """backproject(sino, angles, geometry = 'parallel', **kwargs)
 
     Compute 3D back-projection.
@@ -597,7 +633,7 @@ def backproject(sino, angles, geometry = 'parallel', num_rows=None, num_cols=Non
 
     # validate input arguments
     angles = utils.test_args_angles(angles)
-    sino = utils.test_args_sino(sino,angles)
+    sino = utils.test_args_sino(sino, angles)
 
     if num_threads is None :
         num_threads = cpu_count(logical=False)
@@ -609,32 +645,33 @@ def backproject(sino, angles, geometry = 'parallel', num_rows=None, num_cols=Non
     num_slices = sino.shape[1]
     num_channels = sino.shape[2]
 
-    if num_views != len(angles):
+    if num_views != len(angles) :
         raise Exception('svmbir.backproject(): angles and sinogram arrays have conflicting sizes')
 
     # Geometry dependent settings
-    if geometry == 'parallel':
+    if geometry == 'parallel' :
         dist_source_detector = 0.0
         magnification = 1.0
-    elif geometry == 'fan':
-        if dist_source_detector is None:
+    elif geometry == 'fan' :
+        if dist_source_detector is None :
             raise Exception('For fanbeam geometry, need to specify dist_source_detector')
-    else:
+    else :
         raise Exception('Unrecognized geometry {}'.format(geometry))
 
-    if delta_pixel is None:
-        delta_pixel = delta_channel/magnification
-    if num_rows is None:
-        num_rows,_ = auto_img_size(geometry, num_channels, delta_channel, delta_pixel, magnification)
-    if num_cols is None:
-        _,num_cols = auto_img_size(geometry, num_channels, delta_channel, delta_pixel, magnification)
-    if roi_radius is None:
+    if delta_pixel is None :
+        delta_pixel = delta_channel / magnification
+    if num_rows is None :
+        num_rows, _ = auto_img_size(geometry, num_channels, delta_channel, delta_pixel, magnification)
+    if num_cols is None :
+        _, num_cols = auto_img_size(geometry, num_channels, delta_channel, delta_pixel, magnification)
+    if roi_radius is None :
         roi_radius = auto_roi_radius(delta_pixel, num_rows, num_cols)
 
     paths, sinoparams, imgparams = ci._init_geometry(angles, center_offset=center_offset,
                                                      geometry=geometry, dist_source_detector=dist_source_detector,
                                                      magnification=magnification,
-                                                     num_channels=num_channels, num_views=num_views, num_slices=num_slices,
+                                                     num_channels=num_channels, num_views=num_views,
+                                                     num_slices=num_slices,
                                                      num_rows=num_rows, num_cols=num_cols,
                                                      delta_channel=delta_channel, delta_pixel=delta_pixel,
                                                      roi_radius=roi_radius,
@@ -653,7 +690,7 @@ def backproject(sino, angles, geometry = 'parallel', num_rows=None, num_cols=Non
     return ci.backproject(sino, settings)
 
 
-def _sino_indicator(sino):
+def _sino_indicator( sino ) :
     """Compute a binary function that indicates the region of sinogram support.
 
     Args:

--- a/svmbir/svmbir.py
+++ b/svmbir/svmbir.py
@@ -259,7 +259,7 @@ def recon(sino, angles,
           num_rows = None, num_cols = None, roi_radius = None,
           delta_channel = 1.0, delta_pixel = None, center_offset = 0.0,
           sigma_y = None, snr_db = 40.0, sigma_x = None, sigma_p = None, p = 1.2, q = 2.0, T = 1.0, b_interslice = 1.0,
-          sharpness = 0.0, positivity = True, relax_factor=1.0, max_resolutions = 0, stop_threshold = 0.02, max_iterations = 100,
+          sharpness = 0.0, positivity = True, relax_factor=1.0, max_resolutions = 2, stop_threshold = 0.02, max_iterations = 100,
           num_threads = None, delete_temps = True, svmbir_lib_path = __svmbir_lib_path, object_name = 'object',
           verbose = 1) :
     """recon(sino, angles, geometry = 'parallel', **kwargs)
@@ -329,7 +329,7 @@ def recon(sino, angles,
             when used in applications that can generate negative image values.
         relax_factor (float, optional): [Default=1.0] Relaxation factor for pixel update. Valid range (0,2.0].
             Values in (0,1) produce under-relaxation (smaller step size); Values in (1,2] produce over-relaxation.
-        max_resolutions (int, optional): [Default=0] Integer >=0 that specifies the maximum number of grid 
+        max_resolutions (int, optional): [Default=2] Integer >=0 that specifies the maximum number of grid
             resolutions used to solve MBIR reconstruction problem.
         stop_threshold (float, optional): [Default=0.02] Scalar valued stopping threshold in percent.
             If stop_threshold=0.0, then run max iterations.


### PR DESCRIPTION
This PR modifies the default `snr_db` from 30.0 to 40.0, and `magnification` from None to 1.0 in functions `recon()`, `project()`, and `backproject()`. Also, the checker for `magnification=None` is removed in these functions.

For the corner case where `magnification` of fan beam reconstruction mismatches the real magnification, we should simply get a reconstruction with a scaled intensity.

Tested this corner case with the fanbeam demo script. Passed in the default `magnification=1.0` for `recon()` function. The reconstruction looks identical as before, except that the display window changes from 1.0-1.2 to 0.5-0.6.
