### PR TITLE
Bug fix related to va_arg usage in multialloc

### DIFF
--- a/dev_scripts/build_dist.sh
+++ b/dev_scripts/build_dist.sh
@@ -6,12 +6,11 @@
 # NOT AS: ./build_dist.sh
 # (otherwise it may not activate conda environments)
 #
-# IMPORTANT: If building macOS wheels, run script on macOS 10.14 so that binaries will be
-# compatibile with macOS>=10.14
+# IMPORTANT: If building macOS wheels for x86_64, run script on macOS 10.14 so that binaries will be
+# compatibile with macOS>=10.14. Wheels are delocated to fix a library incompatibility across macOS >= 10.14.
 #
-# Wheels are delocated to fix a library incompatibility across macOS >= 10.14.
+# For macOS arm64 (M1,M2), remove 'delocate' section, and limit to python>=3.8
 #
-
 # Set these accordingly:
 
 python_versions=("3.7" "3.8" "3.9")
@@ -56,12 +55,13 @@ pyv=3.8
 conda create --name sv${pyv} python=$pyv --yes
 conda activate sv${pyv}
 pip install -r requirements.txt
-pip install setuptools delocate
+pip install setuptools
 
 echo "*************** sdist ******************"
 python setup.py sdist
 
 echo "*************** Delocating wheels ******************"
+pip install delocate
 cd dist
 for f in *.whl; do
     delocate-wheel -w fixed_wheels -v $f

--- a/dev_scripts/manylinux.sh
+++ b/dev_scripts/manylinux.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Need manylinux image. To download:
+#       sudo docker pull quay.io/pypa/manylinux2014_x86_64 
+# Open a container:
+#       sudo docker run -it quay.io/pypa/manylinux2014_x86_64 bash
+# In another terminal, copy repo into container:
+#       sudo docker ps      # get CONTAINER ID
+#       sudo docker cp . <CONTAINER_ID>:/io
+# In docker terminal, enter /io and run:
+#       ./manylinux.sh      # DON'T source this, otherwise an exitcode 1 will close shell
+# In host terminal, copy wheels out:
+#       sudo rm -fr wheelhouse
+#       sudo docker cp <CONTAINER_ID>:/io/wheelhouse ./wheelhouse
+#       sudo chown -R $USER wheelhouse
+#       sudo chgrp -R $USER wheelhouse
+
+set -e -u -x
+
+function repair_wheel {
+    wheel="$1"
+    if ! auditwheel show "$wheel"; then
+        echo "Skipping non-platform wheel $wheel"
+    else
+        auditwheel repair "$wheel" --plat "$AUDITWHEEL_PLAT" -w /io/wheelhouse/
+    fi
+}
+
+/bin/rm -frv wheelhouse 2> /dev/null
+
+# Compile wheels
+#for PYBIN in /opt/python/*/bin; do
+for PYBIN in /opt/python/{cp,pp}{37,38,39}*/bin; do
+    #"${PYBIN}/pip" install -r /io/dev_scripts/dev-requirements.txt
+    CC=gcc "${PYBIN}/pip" wheel /io/ --no-deps -w wheelhouse/
+    #CC=gcc "${PYBIN}/python" setup.py bdist_wheel
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/*.whl; do
+    repair_wheel "$whl"
+    /bin/rm -v $whl
+done
+
+# Install packages and test
+#for PYBIN in /opt/python/*/bin/; do
+#    "${PYBIN}/pip" install python-manylinux-demo --no-index -f /io/wheelhouse
+#    (cd "$HOME"; "${PYBIN}/nosetests" pymanylinuxdemo)
+#done

--- a/dev_scripts/test_pypi.sh
+++ b/dev_scripts/test_pypi.sh
@@ -23,7 +23,7 @@ for pyv in ${python_versions[@]}; do
 
     echo "*********** Installing svmbir ${svmbir_version} *************"
     #pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple svmbir==$svmbir_version
-    pip install svmbir==$svmbir_version
+    pip --no-cache-dir install svmbir==$svmbir_version
     pip install -r ../demo/requirements_demo.txt
 
     echo "**** Spinning "


### PR DESCRIPTION
Most importantly, this pulls in a critical fix to the C code related to va_arg usage in multialloc().  On macOS 12.2 (M1) it was observed to produce garbage values for the array size passed to multialloc due to a type mismatch in the va_arg arguments.