### PR TITLE
Remove numpy version from docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.22.*
+numpy
 psutil>=5.8
 Pillow
 Cython


### PR DESCRIPTION
Readthedocs build is failing because of the numpy dependency.  They're building with python 3.7, which numpy==1.22 doesn't support.

Removing the numpy version requirement in docs/requirements.txt should fix this.