### PR TITLE
Loosen numpy requirements; Python 3.7 support

### DIFF
--- a/dev_scripts/build_dist.sh
+++ b/dev_scripts/build_dist.sh
@@ -15,7 +15,8 @@
 #   * macOS/x86_64: Run build on macOS 10.14 for binaries to be compatibile with macOS>=10.14.
 #     Wheels are delocated to fix a library incompatibility across macOS>=10.14.
 #
-#   * macOS/arm64 (M1,M2): CHECK THIS: Limited to python >= 3.8. 'delocation' section will be skipped.
+#   * macOS/arm64 (M1,M2): Limited to python >= 3.8.
+#     Wheels are delocated to include any linked libraries (OpenMP).
 #
 
 python_versions=("3.7" "3.8" "3.9" "3.10")
@@ -75,7 +76,7 @@ pip install setuptools
 python setup.py sdist
 
 # section for pre-M1 macs only
-if [ $(uname -s) = "Darwin" ] && [ $(uname -m) = "x86_64" ]; then
+if [ $(uname -s) = "Darwin" ]; then
     pip install delocate
     echo "******* Delocating wheels *******"
     cd dist

--- a/dev_scripts/build_dist.sh
+++ b/dev_scripts/build_dist.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Builds the sdist and wheels for python 3.8, 3.9, 3.10
+# Builds the sdist and wheels for python 3.7-3.10
 #
 # RUN AS: source build_dist.sh
 # NOT AS: ./build_dist.sh
@@ -9,15 +9,16 @@
 # NOTES:
 #   * Principally for macOS wheels. For linux, build using 'manylinux' from docker image
 #
-#   * starting in v0.3.0, numpy dependency is pinned to 1.22.*, which supports Python 3.8-3.10
+#   * Building with numpy==1.21.6, wheels appear compatible with numpy 1.21-1.23.5 at least
+#     The install requirement numpy>=1.21 then allows support of python 3.7-3.10
 #
 #   * macOS/x86_64: Run build on macOS 10.14 for binaries to be compatibile with macOS>=10.14.
 #     Wheels are delocated to fix a library incompatibility across macOS>=10.14.
 #
-#   * macOS/arm64 (M1,M2): Limited to python >= 3.8. 'delocation' section will be skipped.
+#   * macOS/arm64 (M1,M2): CHECK THIS: Limited to python >= 3.8. 'delocation' section will be skipped.
 #
 
-python_versions=("3.8" "3.9" "3.10")
+python_versions=("3.7" "3.8" "3.9" "3.10")
 CC=gcc
 
 # check for a valid compiler
@@ -48,6 +49,8 @@ for pyv in ${python_versions[@]}; do
     echo "**** Create environment ${pyv} *****"
     conda create --name sv${pyv} python=$pyv --yes
     conda activate sv${pyv}
+    # see note above about numpy version
+    pip install numpy==1.21.6
     pip install -r requirements.txt
     pip install setuptools
 

--- a/dev_scripts/manylinux.sh
+++ b/dev_scripts/manylinux.sh
@@ -34,6 +34,7 @@ for PYBIN in /opt/python/{cp38,cp39,cp310,pp38,pp39}*/bin; do
     echo "***"
     echo "*** building for $PYBIN"
     #"${PYBIN}/pip" install -r /io/dev_scripts/dev-requirements.txt
+    # NOTE: CHECK INSTALL OF numpy=1.21.6, and adding cp37 build
     CC=gcc "${PYBIN}/pip" wheel /io/ --no-deps -w wheelhouse/
     #CC=gcc "${PYBIN}/python" setup.py bdist_wheel
 done

--- a/dev_scripts/manylinux.sh
+++ b/dev_scripts/manylinux.sh
@@ -30,11 +30,11 @@ function repair_wheel {
 
 # Compile wheels
 #for PYBIN in /opt/python/*/bin; do
-for PYBIN in /opt/python/{cp38,cp39,cp310,pp38,pp39}*/bin; do
+for PYBIN in /opt/python/{cp37,cp38,cp39,cp310,pp37,pp38,pp39}*/bin; do
     echo "***"
     echo "*** building for $PYBIN"
     #"${PYBIN}/pip" install -r /io/dev_scripts/dev-requirements.txt
-    # NOTE: CHECK INSTALL OF numpy=1.21.6, and adding cp37 build
+    "${PYBIN}/pip" install numpy==1.21.6    # build with 1.21.6 seems compatible w/ numpy 1.21-1.23
     CC=gcc "${PYBIN}/pip" wheel /io/ --no-deps -w wheelhouse/
     #CC=gcc "${PYBIN}/python" setup.py bdist_wheel
 done

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -12,7 +12,7 @@ Features
 
 System Requirements
 -------------------
-* Python 3.8-3.10
+* Python 3.7-3.10
 
 Local builds also require,
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy==1.22.*", "Cython"]
+requires = ["setuptools", "wheel", "numpy>=1.21.4", "Cython"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.22.*
+numpy>=1.21.4
 psutil>=5.8
 Pillow>=9.1
 Cython

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ packages = [packages_dir]
 src_dir = packages_dir + "/sv-mbirct/src/"
 
 # Dependencies for running svmbir. Dependencies for build/installation are in pyproject.toml
-install_requires=['numpy==1.22.*','psutil>=5.8','Pillow']
+install_requires=['numpy>=1.21.4','psutil>=5.8','Pillow']
 
 
 # Set up install for Cython or Command line interface


### PR DESCRIPTION
Adjusting the build, the user numpy requirement can be changed from numpy==1.22 to numpy>=1.21.

As a consequence we can continue support for Python 3.7 in addition to 3.8-3.10.

I would suggest pushing this out soon to resolve some issues this is causing for lanl/scico. 
