### PR TITLE
Update documentation of fan geometries; add figures and git-lfs filter

### DIFF
--- a/docs/.gitattributes
+++ b/docs/.gitattributes
@@ -1,0 +1,1 @@
+*.png filter=lfs diff=lfs merge=lfs -text

--- a/docs/source/figs/geom-fan-curved.png
+++ b/docs/source/figs/geom-fan-curved.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b85546c421bf1e42daa5575ecabe4903feb9d70f4ef95a8c441a780b59bfa19
+size 160438

--- a/docs/source/figs/geom-fan-flat.png
+++ b/docs/source/figs/geom-fan-flat.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1dffd67a430a3c1c8283c86a39009f1f8ad46917c9c781b05b55140773679d5
+size 143026

--- a/docs/source/figs/geom-fan.png
+++ b/docs/source/figs/geom-fan.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3690cc3b77fff7afb617363cd79275fdf90201f151d493b911226facd8683800
+size 313327

--- a/docs/source/figs/geom-parallel.png
+++ b/docs/source/figs/geom-parallel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72c98666ca276335d3f5b27269b7a66915bf1d99b4fe1d86bfb9e31d75974445
+size 150616

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -16,24 +16,38 @@ When system matrices are computed, they are stored to disk and will be automatic
 
 **Geometry**
 
-**svmbir** currently supports *parallel-beam* and *fan-beam* (equiangular, see below) imaging geometries.
+**svmbir** supports *parallel-beam* and *fan-beam* imaging geometries.
+See the diagrams below for the different fan specifications.
 
-.. figure:: geom-fan.jpg
-   :width: 50%
-   :alt: fan beam geometry
-   :align: center
+.. list-table::
 
-   Equiangular fan-beam geometry
+    * - .. figure:: figs/geom-parallel.png
+           :align: center
 
-.. figure:: geom-parallel.jpg
-   :width: 50%
-   :alt: parallel beam geometry
-   :align: center
+           Parallel-beam geometry
 
-   Parallel-beam geometry
+      - .. figure:: figs/geom-fan.png
+           :align: center
+
+           Fan-beam geometry
+
+    * - .. figure:: figs/geom-fan-curved.png
+           :width: 60%
+           :align: center
+
+           Equiangular (geometry='fan-curved')
+
+      - .. figure:: figs/geom-fan-flat.png
+           :width: 60%
+           :align: center
+
+           Equal spaced (geometry='fan-flat')
 
 
-*View Angle Ordering:* It is common practice to collect view data using techniques such as the "golden ratio" method in which the view angles are not collected in monotonically increasing order on the interval :math:`[0,2\pi)`. While ``svmbir`` will produce the correct reconstruction regardless of view ordering, its reconstruction speed will be substantially degraded when the views are not in monotone order. In this case, we highly recommend that users reorder the sinogram views using the provided ``sino_sort`` function. The ``sino_sort``  function first wraps the view angles modulo :math:`2\pi`, and then sorts the views to be in monotonically increasing order by view angle.
+**Note on view angle ordering**
+
+In certain imaging systems with slow acquisition, it is common practice to collect view data using techniques such as the "golden ratio" method in which the view angles are not collected in monotonically increasing order on the interval :math:`[0,2\pi)`. While ``svmbir`` will produce the correct reconstruction regardless of view ordering, its reconstruction speed will be substantially degraded when the views are not in monotone order. In this case, we highly recommend that users reorder the sinogram views using the provided ``sino_sort`` function. The ``sino_sort``  function first wraps the view angles modulo :math:`2\pi`, and then sorts the views to be in monotonically increasing order by view angle.
+
 
 **Conversion from Arbitrary Length Units (ALU)**
 


### PR DESCRIPTION
This is an update of the documentation to better describe the different fan geometries now supported.

I added better quality png images, and added a git-lfs filter so the image files should be hosted on Git LFS and not in the repo itself.  First time trying this, so need to check the auto readthedocs build after this is merged into master.
