### PR TITLE
update installer, requirements

### DIFF
--- a/dev_scripts/test_pypi.sh
+++ b/dev_scripts/test_pypi.sh
@@ -9,7 +9,7 @@
 # Set these accordingly:
 
 python_versions=("3.7" "3.8" "3.9" "3.10")
-svmbir_version=0.3.1
+svmbir_version=0.3.2
 
 echo "*********************************************************"
 echo "**** Test install "

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.21.4
 psutil>=5.8
-Pillow>=9.1
+Pillow>=9.1,<=9.3
 Cython
 ruamel.yaml
 pytest

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ packages = [packages_dir]
 src_dir = packages_dir + "/sv-mbirct/src/"
 
 # Dependencies for running svmbir. Dependencies for build/installation are in pyproject.toml
-install_requires=['numpy>=1.21.4','psutil>=5.8','Pillow']
+install_requires=['numpy>=1.21.4','psutil>=5.8','Pillow>=9.1,<=9.3']
 
 
 # Set up install for Cython or Command line interface

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ if os.environ.get('CLIB') != 'CMD_LINE':
 
     # Check for compiler env variable. If not set, assume it's a gcc build (linux & macOS only).
     if os.environ.get('CC') not in ['icc','clang','msvc']:
+        os.environ['CC']='gcc'
         extra_compile_args=["-std=c11","-O3","-fopenmp","-Wno-unknown-pragmas"]
         extra_link_args=["-lm","-fopenmp"]
 


### PR DESCRIPTION
A couple fixes to the installers.
Also Pillow 9.4 is causing svmbir import to fail on MacOS/x86_64, so restricting to Pillow<=9.3.
No need to bump svmbir version.