### PR TITLE
merge for release 0.3.3

### DIFF
--- a/dev_scripts/test_pypi.sh
+++ b/dev_scripts/test_pypi.sh
@@ -9,7 +9,7 @@
 # Set these accordingly:
 
 python_versions=("3.7" "3.8" "3.9" "3.10")
-svmbir_version=0.3.2
+svmbir_version=0.3.3
 
 echo "*********************************************************"
 echo "**** Test install "

--- a/docs/.gitattributes
+++ b/docs/.gitattributes
@@ -1,1 +1,0 @@
-*.png filter=lfs diff=lfs merge=lfs -text

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,10 @@ install_requires=['numpy>=1.21.4','psutil>=5.8','Pillow>=9.1,<=9.3']
 if os.environ.get('CLIB') != 'CMD_LINE':
 
     # Check for compiler env variable. If not set, assume it's a gcc build (linux & macOS only).
-    if os.environ.get('CC') not in ['icc','clang','msvc']:
+    if os.environ.get('CC') is None:
         os.environ['CC']='gcc'
+
+    if os.environ.get('CC') not in ['icc','clang','msvc']:
         extra_compile_args=["-std=c11","-O3","-fopenmp","-Wno-unknown-pragmas"]
         extra_link_args=["-lm","-fopenmp"]
 

--- a/svmbir/__init__.py
+++ b/svmbir/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 from .svmbir import *
 from .phantom import *
 __all__ = ['recon','project','backproject','sino_sort','calc_weights','auto_sigma_x','auto_sigma_y','auto_sigma_p','_clear_cache','_svmbir_lib_path']


### PR DESCRIPTION
Had to make a fix in setup.py for the conda-forge build. This requires new source distribution, so new version.

- Update requirements with Pillow<=9.3 (9.4 is causing import fail on MacOS/x86_64)
- Update setup.py for MacOS builds