### PR TITLE
Sphinx hotfix

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,10 @@
+sphinx
+sphinx-rtd-theme
+sphinxcontrib-bibtex
 numpy
 psutil>=5.8
 Pillow
 Cython
 ruamel.yaml
 pytest
-sphinx>=2.2
-sphinxcontrib-bibtex==1.0
-sphinx-rtd-theme~=0.5.1
 ipython>=6.3.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,8 @@ extensions = [
     'sphinx.ext.viewcode'
 ]
 
+bibtex_bibfiles = ["bibtex/ref.bib"]
+
 exclude_patterns = ['_build', '**.ipynb_checkpoints']
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This is a fix to the sphinx docs.
Charlie previously had the following error:
```
Extension error:
You must configure the bibtex_bibfiles setting
```

This is because the bib file was not specified in `docs/source/conf.py`

The readthedocs should build without issues now.